### PR TITLE
Opening of configuration of integration caused internal server error

### DIFF
--- a/custom_components/control_my_spa/config_flow.py
+++ b/custom_components/control_my_spa/config_flow.py
@@ -87,5 +87,5 @@ class ControlMySpaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> ControlMySpaOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return ControlMySpaOptionsFlowHandler(config_entry)
+        return ControlMySpaOptionsFlowHandler()
 

--- a/custom_components/control_my_spa/options_flow.py
+++ b/custom_components/control_my_spa/options_flow.py
@@ -6,10 +6,6 @@ from .const import DOMAIN
 class ControlMySpaOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle options flow for ControlMySpa."""
 
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
     def _get_component_count(self, component_type, prefix, default_min):
         """Získá počet komponent z shared_data, pokud jsou dostupná.
         


### PR DESCRIPTION
<img width="925" height="560" alt="image" src="https://github.com/user-attachments/assets/55464a07-a3df-4219-9313-5d672d650307" />

Error from log:
AttributeError: property 'config_entry' of 'ControlMySpaOptionsFlowHandler' object has no setter

Handling of config_entry is already done in base class.

Best regards!