### PR TITLE
Add fault message and total alerts sensors

### DIFF
--- a/custom_components/control_my_spa/ControlMySpa.py
+++ b/custom_components/control_my_spa/ControlMySpa.py
@@ -197,6 +197,8 @@ class ControlMySpa:
                 'serialNumber': spaData['serialNumber'],
                 'controllerSoftwareVersion': spaData['systemInfo']['controllerSoftwareVersion'],
                 'isOnline': bool(spaData.get('isOnline')),
+                'currentFaultMessage': spaData.get('currentFaultMessage'),
+                'totalAlerts': spaData.get('totalAlerts'),
             }
             
             # Načtení TZL zones pokud je TZL připojen

--- a/custom_components/control_my_spa/sensor/__init__.py
+++ b/custom_components/control_my_spa/sensor/__init__.py
@@ -16,6 +16,7 @@ from .energy import (
     SpaBlowerEnergySensor,
     SpaCirculationPumpEnergySensor
 )
+from .alerts import SpaFaultMessageSensor, SpaTotalAlertsSensor
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -101,6 +102,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
     # Vytvořit energy senzory pro circulation pumps (pro Energy Dashboard - kWh)
     entities += [SpaCirculationPumpEnergySensor(shared_data, device_info, unique_id_suffix, pump_data, len(circulation_pumps), config_options) for pump_data in circulation_pumps]
 
+    entities.append(SpaFaultMessageSensor(shared_data, device_info, unique_id_suffix))
+    entities.append(SpaTotalAlertsSensor(shared_data, device_info, unique_id_suffix))
+
     async_add_entities(entities, True)
     _LOGGER.debug("START Śensor control_my_spa")
     
@@ -120,6 +124,8 @@ __all__ = [
     "SpaPumpEnergySensor",
     "SpaBlowerEnergySensor",
     "SpaCirculationPumpEnergySensor",
+    "SpaFaultMessageSensor",
+    "SpaTotalAlertsSensor",
     "async_setup_entry",
 ]
 

--- a/custom_components/control_my_spa/sensor/alerts.py
+++ b/custom_components/control_my_spa/sensor/alerts.py
@@ -1,0 +1,66 @@
+"""Alert and fault message sensor entities."""
+
+from homeassistant.components.sensor import SensorStateClass
+from .base import SpaSensorBase
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SpaFaultMessageSensor(SpaSensorBase):
+    def __init__(self, shared_data, device_info, unique_id_suffix):
+        self._shared_data = shared_data
+        self._state = None
+        self._attr_should_poll = False
+        self._attr_icon = "mdi:alert-circle"
+        self._attr_device_info = device_info
+        self._attr_unique_id = f"sensor.spa_fault_message{unique_id_suffix}"
+        self._attr_translation_key = "fault_message"
+        self.entity_id = self._attr_unique_id
+
+    async def async_update(self):
+        data = self._shared_data.data
+        if data:
+            fault = data.get("currentFaultMessage")
+            if isinstance(fault, dict):
+                self._state = fault.get("description")
+                self._attrs = {
+                    "code": fault.get("code"),
+                    "severity": fault.get("severity"),
+                    "controller_type": fault.get("controllerType"),
+                }
+            else:
+                self._state = fault
+                self._attrs = {}
+            _LOGGER.debug("Updated fault message: %s", self._state)
+
+    @property
+    def native_value(self):
+        return self._state
+
+    @property
+    def extra_state_attributes(self):
+        return getattr(self, "_attrs", {})
+
+
+class SpaTotalAlertsSensor(SpaSensorBase):
+    def __init__(self, shared_data, device_info, unique_id_suffix):
+        self._shared_data = shared_data
+        self._state = None
+        self._attr_should_poll = False
+        self._attr_icon = "mdi:bell-alert"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_device_info = device_info
+        self._attr_unique_id = f"sensor.spa_total_alerts{unique_id_suffix}"
+        self._attr_translation_key = "total_alerts"
+        self.entity_id = self._attr_unique_id
+
+    async def async_update(self):
+        data = self._shared_data.data
+        if data:
+            self._state = data.get("totalAlerts")
+            _LOGGER.debug("Updated total alerts: %s", self._state)
+
+    @property
+    def native_value(self):
+        return self._state

--- a/custom_components/control_my_spa/translations/en.json
+++ b/custom_components/control_my_spa/translations/en.json
@@ -155,6 +155,12 @@
       },
       "blower_energy_3": {
         "name": "Blower energy consumption 3"
+      },
+      "fault_message": {
+        "name": "Fault message"
+      },
+      "total_alerts": {
+        "name": "Total alerts"
       }
     },
     "light": {


### PR DESCRIPTION
## Summary

- Exposes `currentFaultMessage` from the API as `sensor.spa_fault_message` — shows the fault description (e.g. *Clean the filter*) with `code`, `severity` and `controller_type` as attributes
- Exposes `totalAlerts` from the API as `sensor.spa_total_alerts` — shows the number of active alerts
- Both fields were already returned by the `/spas/{id}/dashboard` endpoint but were not included in `constructCurrentState` or surfaced as entities

## Changes

- `ControlMySpa.py`: include `currentFaultMessage` and `totalAlerts` in `constructCurrentState` result
- `sensor/alerts.py`: new file with `SpaFaultMessageSensor` and `SpaTotalAlertsSensor`
- `sensor/__init__.py`: import and register the new sensors
- `translations/en.json`: add translation keys `fault_message` and `total_alerts`

## Test plan

- [x] Verify `sensor.spa_fault_message` shows fault description text when a fault is active, `unknown` when no fault
- [x] Verify `sensor.spa_total_alerts` shows correct count
- [x] Verify attributes (`code`, `severity`, `controller_type`) are present on fault message sensor

🤖 Generated with [Claude Code](https://claude.com/claude-code)