### PR TITLE
fix: bound aiohttp ClientSession with a 20s request timeout

### DIFF
--- a/custom_components/control_my_spa/ControlMySpa.py
+++ b/custom_components/control_my_spa/ControlMySpa.py
@@ -26,7 +26,10 @@ class ControlMySpa:
 
     async def init_session(self):
         if self.session is None:
-            self.session = aiohttp.ClientSession()
+            # 20s total timeout per request keeps a stalled cloud call from
+            # blocking the 60s periodic update tick (aiohttp's 5-min default
+            # left last_reported frozen long enough to trip the stale alert).
+            self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=20))
 
     async def close(self):
         if self.session:


### PR DESCRIPTION
## Problem

  `ControlMySpa.__init__` creates `aiohttp.ClientSession()` with no timeout, so
  every request inherits aiohttp's 5-minute default. When the ControlMySpa cloud
  hangs a connection (intermittent 504s and TCP stalls are common), the periodic
  60s update tick blocks for up to 5 minutes. During that block:

  - `_notify_subscribers()` is never reached → no `async_write_ha_state()` →
  entity `last_reported` does not advance.
  - The next minute's `async_track_time_interval` tick fires concurrently, piling
  up stuck requests on the single shared session.

  Downstream effect: any HA template/automation watching `last_reported` (e.g. a
  "my spa API is stale" watchdog) will trip even though the cloud will eventually
  respond.

  ## Fix

  Pass an explicit `ClientTimeout(total=20)` when constructing the session. 20 s
  is well under the 60 s tick interval, so a stalled request fails fast, the next
  tick retries cleanly, and a real outage surfaces as a logged `GetSpa Error:
  TimeoutError` instead of silent staleness.

  ```python
  self.session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=20))

  The existing try/except around every API call already catches
  asyncio.TimeoutError / aiohttp.ClientError and logs them, so the new behavior is
   observable without further changes.

  Notes

  - Per-session timeout means every call goes through it — login(), getSpa(),
  getSpaOwner(), and every _postAndRefresh(...). No per-call edits needed.
  - 20 s is conservative for a cloud round-trip; could be tuned lower (10 s) if
  you'd prefer. Open to suggestions.