### PR TITLE
fix: resume polling after heater-mode change (was paused forever)

### DIFF
--- a/custom_components/control_my_spa/select/temperature.py
+++ b/custom_components/control_my_spa/select/temperature.py
@@ -237,15 +237,18 @@ class SpaHeaterModeSelect(SpaSelectBase):
 
         try:
             self._shared_data.pause_updates()
-            
+
             # První pokus
             success = await self._try_set_heater_mode(option)
-            
+
             # Druhý pokus pokud první selhal
             if not success:
                 _LOGGER.info("Zkouším znovu nastavit režim ohřevu na %s", option)
                 success = await self._try_set_heater_mode(option, True)
-                
+
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error setting heater mode to %s: %s", option, str(e))
+            raise
+        finally:
+            self._shared_data.resume_updates()


### PR DESCRIPTION
## Problem

  `SpaHeaterModeSelect.async_select_option` calls
  `self._shared_data.pause_updates()` but has no `finally: resume_updates()`
  clause (and the `except` swallows the exception too). Once the heater mode is
  changed, periodic polling is paused and never restarted — until some *other*
  entity's action happens to call `resume_updates()` from its own try/finally.

  The sibling `SpaTempRangeSelect.async_select_option`, directly above in the same
   file, has the correct pattern. The heater-mode version looks like a copy-paste
  that lost the `raise` + `finally` block:

  ```python
  # SpaTempRangeSelect (correct, lines ~149-167)
  try:
      self._shared_data.pause_updates()
      ...
      await self._shared_data.async_force_update()
  except Exception as e:
      _LOGGER.error("Error setting temperature range to %s: %s", option, str(e))
      raise
  finally:
      self._shared_data.resume_updates()

  # SpaHeaterModeSelect (buggy, lines ~233-251)
  try:
      self._shared_data.pause_updates()
      ...
      await self._shared_data.async_force_update()
  except Exception as e:
      _LOGGER.error("Error setting heater mode to %s: %s", option, str(e))
  # ^ no `raise`, no `finally: resume_updates()`

  Evidence

  I instrumented SpaData._periodic_update with a one-line heartbeat that logs the
  gap since the previous tick. Over a 22-hour window I saw:

  - 3 hours of healthy 60.0 s ticks
  - An 8 h 35 m dormancy starting 17:44:50 — immediately after a
  select.spa_heater_mode automation set REST at the 17:00 price boundary
  - A 10 h 32 m dormancy starting 02:29:57 — immediately after another heater-mode
   READY set

  When ticks did run, data=OK 100% of the time. So this wasn't HTTP failure; it
  was the async_track_time_interval handle being cancelled by pause_updates() and
  never re-armed.

  After applying this fix and re-running the heartbeat for 62 h: 3,691 ticks, max
  gap 187 s (mode-change jitter), zero multi-hour dormancy.

  Fix

  Add the missing raise + finally: resume_updates(), matching the sibling:

  async def async_select_option(self, option: str):
      if option not in self._attr_options:
          return
      try:
          self._shared_data.pause_updates()
          ...
          await self._shared_data.async_force_update()
      except Exception as e:
          _LOGGER.error("Error setting heater mode to %s: %s", option, str(e))
          raise
      finally:
          self._shared_data.resume_updates()

  Reproduction

  1. Have any HA automation periodically call select.select_option on
  select.spa_heater_mode (in our setup, two automations fire on electricity price
  boundaries — happens every 15–60 min).
  2. Observe that periodic polling stops after each call until another entity
  command (pump switch, light, etc.) calls resume_updates() from its own
  try/finally.

  The bug is more visible when the integration is heavily automated; users who
  only touch heater mode via the UI may not notice because they'll usually touch
  other entities too.