### PR TITLE
fix: strip trailing whitespace from /spa-commands/time URL

### DIFF
--- a/custom_components/control_my_spa/ControlMySpa.py
+++ b/custom_components/control_my_spa/ControlMySpa.py
@@ -264,7 +264,7 @@ class ControlMySpa:
         })
 
     async def setTime(self, date, time, military_format=True):
-        return await self._postAndRefresh("/spa-commands/time   ", {
+        return await self._postAndRefresh("/spa-commands/time", {
             "spaId": self.spaId,
             "via": "MOBILE",
             "date": date,


### PR DESCRIPTION
## Problem

  `ControlMySpa.setTime()` POSTs to `"/spa-commands/time   "` — three trailing spaces.
  The URL builder encodes them as `%20%20%20`, producing
  `/spa-commands/time%20%20%20`, which the API answers with 404. As a result,
  **the time-sync feature has never worked**: the `update_time` service
  (`services.yaml`) and the `button.spa_update_time` entity, both of which
  ultimately call `setTime()`, fail silently with an error logged at every
  invocation.

  ## Evidence (from my HA log before the fix)

  ```
  2026-05-14 03:30:02.641 ERROR [custom_components.control_my_spa.ControlMySpa] Error in /spa-commands/time   : {"message":"Cannot POST
  /spa-commands/time%20%20%20","error":"Not Found","statusCode":404} Data: {'spaId': '...', 'via': 'MOBILE', 'date': '2026-05-14', 'time': '03:30',
  'isMilitaryFormat': True}
  ```

  This recurred daily because my HA automation calls `button.spa_update_time`
  once a day to correct controller-clock drift (DST and RTC drift).
  After applying the one-character fix, the 03:30 error went away and the
  spa's onboard clock actually advances.

  ## Fix

  ```python
  # was
  return await self._postAndRefresh("/spa-commands/time   ", { ... })
  # now
  return await self._postAndRefresh("/spa-commands/time", { ... })
  ```

  ## Why it likely went unnoticed

  `setTime()` is only reached when the user manually invokes the
  `update_time` service or the `Update spa time` button — neither is on a
  typical user's daily path. The error is logged at ERROR but doesn't
  surface as a visible UI failure because both call sites swallow the
  `None` return.