### PR TITLE
feat: add spa_clock diagnostic sensor

### DIFF
--- a/custom_components/control_my_spa/sensor/__init__.py
+++ b/custom_components/control_my_spa/sensor/__init__.py
@@ -18,6 +18,7 @@ from .energy import (
 )
 from .alerts import SpaFaultMessageSensor, SpaTotalAlertsSensor
 from .c8z_heater_sensor import SpaC8zHeaterStateSensor, SpaC8zStatusSensor
+from .clock import SpaClockSensor
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -111,6 +112,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entitie
             entities.append(SpaC8zHeaterStateSensor(shared_data, device_info, unique_id_suffix))
         if "c8zStatus" in c8z:
             entities.append(SpaC8zStatusSensor(shared_data, device_info, unique_id_suffix))
+    entities.append(SpaClockSensor(shared_data, device_info, unique_id_suffix))
 
     async_add_entities(entities, True)
     _LOGGER.debug("START Śensor control_my_spa")
@@ -135,6 +137,7 @@ __all__ = [
     "SpaTotalAlertsSensor",
     "SpaC8zHeaterStateSensor",
     "SpaC8zStatusSensor",
+    "SpaClockSensor",
     "async_setup_entry",
 ]
 

--- a/custom_components/control_my_spa/sensor/clock.py
+++ b/custom_components/control_my_spa/sensor/clock.py
@@ -1,0 +1,32 @@
+"""Clock sensor exposing the time reported by the spa control panel."""
+
+from homeassistant.helpers.entity import EntityCategory
+from .base import SpaSensorBase
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SpaClockSensor(SpaSensorBase):
+    """Diagnostic sensor showing the time configured on the spa panel."""
+
+    def __init__(self, shared_data, device_info, unique_id_suffix):
+        self._shared_data = shared_data
+        self._state = None
+        self._attr_should_poll = False
+        self._attr_icon = "mdi:clock-outline"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_device_info = device_info
+        self._attr_unique_id = f"sensor.spa_clock{unique_id_suffix}"
+        self._attr_translation_key = "spa_clock"
+        self.entity_id = self._attr_unique_id
+
+    async def async_update(self):
+        data = self._shared_data.data
+        if data:
+            self._state = data.get("time")
+            _LOGGER.debug("Updated spa clock: %s", self._state)
+
+    @property
+    def native_value(self):
+        return self._state

--- a/custom_components/control_my_spa/translations/cs.json
+++ b/custom_components/control_my_spa/translations/cs.json
@@ -167,6 +167,9 @@
       },
       "c8z_status": {
         "name": "Stav C8Z"
+      },
+      "spa_clock": {
+        "name": "Čas vířivky"
       }
     },
     "select": {

--- a/custom_components/control_my_spa/translations/da.json
+++ b/custom_components/control_my_spa/translations/da.json
@@ -167,6 +167,9 @@
       },
       "c8z_status": {
         "name": "C8Z status"
+      },
+      "spa_clock": {
+        "name": "Spa-ur"
       }
     },
     "light": {

--- a/custom_components/control_my_spa/translations/de.json
+++ b/custom_components/control_my_spa/translations/de.json
@@ -149,6 +149,9 @@
       },
       "c8z_status": {
         "name": "C8Z Status"
+      },
+      "spa_clock": {
+        "name": "Spa-Uhr"
       }
     },
     "select": {

--- a/custom_components/control_my_spa/translations/en.json
+++ b/custom_components/control_my_spa/translations/en.json
@@ -167,6 +167,9 @@
       },
       "c8z_status": {
         "name": "C8Z status"
+      },
+      "spa_clock": {
+        "name": "Spa clock"
       }
     },
     "light": {


### PR DESCRIPTION
## What

  Adds a small read-only diagnostic sensor `sensor.spa_clock` exposing the time
  reported by the spa control panel (the `time` field already present in the
  dashboard payload and decoded in `constructCurrentState`).

  ```python
  # custom_components/control_my_spa/sensor/clock.py
  class SpaClockSensor(SpaSensorBase):
      _attr_entity_category = EntityCategory.DIAGNOSTIC
      _attr_icon = "mdi:clock-outline"
      _attr_translation_key = "spa_clock"
      # ...

      async def async_update(self):
          data = self._shared_data.data
          if data:
              self._state = data.get("time")
  ```

  Wired into `sensor/__init__.py` (import + entity registration + `__all__`),
  translations added for **en / da / cs / de**.

  ## Why

  The spa's onboard clock has no NTP and no automatic DST handling, so it
  drifts over time and gets an hour off twice a year. The integration
  already provides an `update_time` service and a `button.spa_update_time`
  entity to push the current host time back to the spa.

  What's missing is **visibility**: the user can fire `update_time`, but
  they can't see whether the spa's clock currently disagrees with HA, so
  the only safe pattern is to push the time blindly on a daily timer.
  Exposing the spa's reported time as a sensor lets users build
  drift-aware automations that only call `update_time` when the panel
  actually disagrees with HA — for example:

  ```yaml
  - id: spa-daily-time-sync
    triggers:
      - trigger: time
        at: "03:30:00"
    conditions:
      - condition: template
        value_template: >-
          {% set spa = states('sensor.spa_clock') %}
          {% if spa in ['unknown', 'unavailable', 'none', None] %}false
          {% else %}
            {% set sp = spa.split(':') %}
            {% set spa_min = sp[0]|int * 60 + sp[1]|int %}
            {% set ha_min = now().hour * 60 + now().minute %}
            {% set diff = ((spa_min - ha_min) + 720) % 1440 - 720 %}
            {{ diff|abs >= 5 }}
          {% endif %}
    actions:
      - action: button.press
        target:
          entity_id: button.spa_update_time
  ```

  I've been running this in production for a couple of months and it
  correctly fires once on each DST transition and is otherwise silent.

  ## Scope and risk

  - New file, ~32 lines. No changes to existing entities or update flow.
  - Diagnostic category, so it's hidden from the main device card by default.
  - The `time` value is what `constructCurrentState` already produces from
    the dashboard payload — no new API calls.
  - Backward-compatible.

  ## Notes

  The data shape is `"HH:MM"` as 24-hour military format (the panel value
  the dashboard returns). Could be tightened to a proper `time` device
  class in a follow-up if you'd like, but the bare string is what
  templates need most often.