### PR TITLE
Add SpaPanelLockSwitch entity class to the switch platform

### DIFF
--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -1,4 +1,3 @@
-from ast import Await
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
 from .const import DOMAIN
@@ -19,36 +18,24 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if not shared_data.data:
         return False
 
-    # Najít všechny LIGHT komponenty s přesně dvěma hodnotami
     lights = [
         component for component in shared_data.data["components"]
-        if component["componentType"] == "LIGHT" and 
+        if component["componentType"] == "LIGHT" and
         len(component.get("availableValues", ["OFF", "HIGH"])) == 2
     ]
-    # Najít všechny PUMP komponenty s přesně dvěma hodnotami
     pumps = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "PUMP"
     ]
-    # Najít všechny BLOWER komponenty
     blowers = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "BLOWER"
     ]
-    # Najít všechny FILTER komponenty
     filters = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "FILTER"
     ]
-    # Najít všechny PUMP komponenty s LOW nebo MED hodnotami (pro SpaPumpLowSwitch)
-    # pumps_low = [
-    #     component for component in shared_data.data["components"]
-    #     if component["componentType"] == "PUMP" and
-    #     len(component.get("availableValues", [])) >= 2 and
-    #     any(val in component.get("availableValues", []) for val in ["LOW", "MED"])
-    # ]
 
-    # Logování informací o filtrování
     _LOGGER.debug(
         "Filtered components for Switch - Lights: %d, Pumps: %d, Pumps Low: %d, Blowers: %d, Filters: %d",
         len(lights),
@@ -60,18 +47,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = [SpaLightSwitch(shared_data, device_info, unique_id_suffix, light, len(lights)) for light in lights]
     entities += [SpaPumpSwitch(shared_data, device_info, pump, len(pumps), unique_id_suffix) for pump in pumps]
-    # entities += [SpaPumpLowSwitch(shared_data, device_info, pump, len(pumps_low), unique_id_suffix) for pump in pumps_low]
     entities += [SpaBlowerSwitch(shared_data, device_info, unique_id_suffix, blower, len(blowers)) for blower in blowers]
-    
-    # Přidání switch pro druhý filtr pouze pokud existují dva filtry
+
     if len(filters) >= 2:
         entities.append(SpaFilter2Switch(shared_data, device_info, unique_id_suffix, client))
-    
-    # Přidání TZL přepínače pouze pokud jsou k dispozici TZL zóny
+
     tzl_zones = shared_data.data.get("tzlZones", [])
     if tzl_zones:
         entities.append(SpaTzlPowerSwitch(shared_data, device_info, unique_id_suffix, client))
-    
+
+    entities.append(SpaPanelLockSwitch(shared_data, device_info, unique_id_suffix, client))
+
     async_add_entities(entities, True)
     _LOGGER.debug("START Switch control_my_spa")
 
@@ -79,8 +65,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         shared_data.register_subscriber(entity)
         _LOGGER.debug("Created Switch (%s) (%s)", entity._attr_unique_id, entity.entity_id)
 
+
 class SpaSwitchBase(SwitchEntity):
     _attr_has_entity_name = True
+
 
 class SpaLightSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, unique_id_suffix, light_data, light_count):
@@ -97,28 +85,25 @@ class SpaLightSwitch(SpaSwitchBase):
         self._attr_unique_id = f"{base_id}{unique_id_suffix}"
         self._attr_translation_key = f"light" if light_count == 1 or light_data['port'] == None else f"light_{int(light_data['port']) + 1}"
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro světlo, výchozí hodnoty jsou OFF a HIGH
         self._available_values = light_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = self._available_values[0]  # První hodnota pro vypnuto
-        self._on_value = self._available_values[-1]  # Poslední hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = self._available_values[0]
+        self._on_value = self._available_values[-1]
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:lightbulb-on"
         else:
             return "mdi:lightbulb"
 
     def _get_light_state(self, data):
-        """Získá stav světla z dat."""
         if not data:
             return None
         light = next(
@@ -138,55 +123,47 @@ class SpaLightSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_light_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu světla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setLightState(device_number, target_state)
             if response_data is None:
                 _LOGGER.warning("Function setLightState, parameter %s is not supported", target_state)
                 return False
             new_state = self._get_light_state(response_data)
-            
             if new_state == target_state:
                 self._attr_is_on = (target_state == self._on_value)
                 _LOGGER.info(
-                    "Úspěšně %s světlo %s%s",
-                    "zapnuto" if target_state == self._on_value else "vypnuto",
+                    "Successfully %s light %s%s",
+                    "turned on" if target_state == self._on_value else "turned off",
                     self._light_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Light %s was not %s. Expected state: %s, Current state: %s%s",
+                    "Light %s was not %s. Expected: %s, Got: %s%s",
                     self._light_data["port"],
-                    "zapnuto" if target_state == self._on_value else "vypnuto",
+                    "turned on" if target_state == self._on_value else "turned off",
                     target_state,
                     new_state,
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._light_data["port"])
-            
-            # První pokus
             success = await self._try_set_light_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout světlo %s", self._light_data["port"])
+                _LOGGER.info("Retrying light on %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on light (port %s): %s", self._light_data["port"], str(e))
@@ -198,23 +175,19 @@ class SpaLightSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._light_data["port"])
-            
-            # První pokus
             success = await self._try_set_light_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout světlo %s", self._light_data["port"])
+                _LOGGER.info("Retrying light off %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off light (port %s): %s", self._light_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaPumpSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, pump_data, pump_count, unique_id_suffix=""):
@@ -235,42 +208,34 @@ class SpaPumpSwitch(SpaSwitchBase):
             else f"pump_{int(pump_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro pump, výchozí hodnoty jsou OFF a HIGH
         self._available_values = pump_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = "OFF"  # Pevná hodnota pro vypnuto
-        self._on_value = "HIGH"  # Pevná hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = "OFF"
+        self._on_value = "HIGH"
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-windy"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota 'LOW'
         if value == "LOW":
-            # Pokud mezi dostupnými není MED ani HIGH ani HI → nastav OFF
             if "MED" not in self._available_values and "HIGH" not in self._available_values and "HI" not in self._available_values:
                 return True
-            # Pokud není MED, ale je HIGH → nastav HIGH
             elif "MED" not in self._available_values and ("HIGH" in self._available_values or "HI" in self._available_values):
                 return False
-            # Pokud je MED → nastav MED
             elif "MED" in self._available_values:
                 return False
             else:
                 return True
-        # Pokud je hodnota 'MED', ověřit zda je HIGH v availableValues
         elif value == "MED":
             if "HIGH" in self._available_values:
                 return False
@@ -293,10 +258,8 @@ class SpaPumpSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_pump_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu čerpadla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setJetState(device_number, target_state)
             if response_data is None:
@@ -307,51 +270,41 @@ class SpaPumpSwitch(SpaSwitchBase):
                 None
             )
             new_state = pump["value"] if pump else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s čerpadlo %s%s",
-                    "zapnuto" if expected_is_on else "vypnuto",
+                    "Successfully %s pump %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._pump_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Pump %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._pump_data["port"],
-                    "zapnuto" if expected_is_on else "vypnuto",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout čerpadlo %s", self._pump_data["port"])
+                _LOGGER.info("Retrying pump on %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on pump (port %s): %s", self._pump_data["port"], str(e))
@@ -363,23 +316,19 @@ class SpaPumpSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout čerpadlo %s", self._pump_data["port"])
+                _LOGGER.info("Retrying pump off %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off pump (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaPumpLowSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, pump_data, pump_count, unique_id_suffix=""):
@@ -400,41 +349,35 @@ class SpaPumpLowSwitch(SpaSwitchBase):
             else f"low_pump_{int(pump_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro pump, výchozí hodnoty jsou OFF a HIGH
         self._available_values = pump_data.get("availableValues", ["LOW", "HIGH"])
-        # Nastavení _off_value: LOW má nižší stav, pokud tam je MED
         if "LOW" in self._available_values:
             self._off_value = "LOW"
         elif "MED" in self._available_values:
             self._off_value = "MED"
         else:
             self._off_value = self._available_values[0] if self._available_values else "OFF"
-        # Nastavení _on_value: nejvyšší dostupná hodnota z MED nebo HIGH
         if "HIGH" in self._available_values or "HI" in self._available_values:
             self._on_value = "HIGH"
         elif "MED" in self._available_values:
             self._on_value = "MED"
         else:
             self._on_value = self._available_values[-1] if self._available_values else "HIGH"
-        self._is_processing = False  # Příznak zpracování
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-windy"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota rovna _on_value (HIGH nebo MED), pak je to ON
         return value == self._on_value
 
     async def async_update(self):
@@ -451,68 +394,55 @@ class SpaPumpLowSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_pump_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu čerpadla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setJetState(device_number, target_state)
             if response_data is None:
                 _LOGGER.warning("Function setJetState, parameter %s is not supported", target_state)
                 return False
-
             pump = next(
                 (comp for comp in response_data["components"] if comp["componentType"] == "PUMP" and comp["port"] == self._pump_data["port"]),
                 None
             )
             new_state = pump["value"] if pump else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s čerpadlo Low %s%s",
-                    "zapnuto" if expected_is_on else "vypnuto",
+                    "Successfully %s pump low %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._pump_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump Low %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Pump Low %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._pump_data["port"],
-                    "zapnuto" if expected_is_on else "vypnuto",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._on_value)
-            
-            # Logování pokud první pokus selhal (bez druhého pokusu)
             if not success:
-                _LOGGER.info("První pokus o zapnutí čerpadla Low %s selhal", self._pump_data["port"])
-                
+                _LOGGER.info("First attempt to turn on pump low %s failed", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
+        except ValueError:
+            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning on pump Low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning on pump low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
@@ -521,22 +451,18 @@ class SpaPumpLowSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._off_value)
-            
-            # Logování pokud první pokus selhal (bez druhého pokusu)
             if not success:
-                _LOGGER.info("První pokus o vypnutí čerpadla Low %s selhal", self._pump_data["port"])
-                
+                _LOGGER.info("First attempt to turn off pump low %s failed", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
+        except ValueError:
+            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning off pump Low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning off pump low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaBlowerSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, unique_id_suffix, blower_data, blower_count):
@@ -557,42 +483,34 @@ class SpaBlowerSwitch(SpaSwitchBase):
             else f"blower_{int(blower_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro blower, výchozí hodnoty jsou OFF a HIGH
         self._available_values = blower_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = "OFF"  # Pevná hodnota pro vypnuto
-        self._on_value = "HIGH"  # Pevná hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = "OFF"
+        self._on_value = "HIGH"
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-dust"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota 'LOW'
         if value == "LOW":
-            # Pokud mezi dostupnými není MED ani HIGH ani HI → nastav OFF
             if "MED" not in self._available_values and "HIGH" not in self._available_values and "HI" not in self._available_values:
                 return False
-            # Pokud není MED, ale je HIGH → nastav HIGH
             elif "MED" not in self._available_values and ("HIGH" in self._available_values or "HI" in self._available_values):
                 return True
-            # Pokud je MED → nastav MED
             elif "MED" in self._available_values:
                 return True
             else:
                 return False
-        # Pokud je hodnota 'MED', ověřit zda je HIGH v availableValues
         elif value == "MED":
             if "HIGH" in self._available_values:
                 return True
@@ -615,10 +533,8 @@ class SpaBlowerSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_blower_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu vzduchovače s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setBlowerState(device_number, target_state)
             if response_data is None:
@@ -629,51 +545,41 @@ class SpaBlowerSwitch(SpaSwitchBase):
                 None
             )
             new_state = blower["value"] if blower else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s vzduchovač %s%s",
-                    "zapnut" if expected_is_on else "vypnut",
+                    "Successfully %s blower %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._blower_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Blower %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Blower %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._blower_data["port"],
-                    "zapnut" if expected_is_on else "vypnut",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._blower_data["port"])
-            
-            # První pokus
             success = await self._try_set_blower_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout vzduchovač %s", self._blower_data["port"])
+                _LOGGER.info("Retrying blower on %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on blower (port %s): %s", self._blower_data["port"], str(e))
@@ -685,17 +591,12 @@ class SpaBlowerSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._blower_data["port"])
-            
-            # První pokus
             success = await self._try_set_blower_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout vzduchovač %s", self._blower_data["port"])
+                _LOGGER.info("Retrying blower off %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off blower (port %s): %s", self._blower_data["port"], str(e))
@@ -703,11 +604,11 @@ class SpaBlowerSwitch(SpaSwitchBase):
         finally:
             self._shared_data.resume_updates()
 
+
 class SpaTzlPowerSwitch(SpaSwitchBase):
-    """Přepínač pro zapnutí/vypnutí TZL světel."""
+    """Switch for TZL/Chromazone lighting power."""
 
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
-        """Inicializace TZL přepínače."""
         self._shared_data = shared_data
         self._attr_device_info = device_info
         self._client = client
@@ -718,83 +619,68 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
-        
+
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:lightbulb-group"
         else:
             return "mdi:lightbulb-group-off"
 
     def _get_tzl_power_state(self, data):
-        """Získá stav TZL světel z dat."""
         if not data:
             return False
         tzl_zones = data.get("tzlZones", [])
         if not tzl_zones:
             return False
-        # Přepínač je ON, pokud alespoň jedna zóna není ve stavu OFF
         return any(zone.get("state") != "OFF" for zone in tzl_zones)
 
     async def async_update(self):
-        """Aktualizace stavu přepínače."""
         data = self._shared_data.data
         if data:
             self._attr_is_on = self._get_tzl_power_state(data)
             _LOGGER.debug("Updated TZL Power: %s", self._attr_is_on)
 
     async def _try_set_tzl_power_state(self, power_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu TZL světel s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._client.setChromazonePower(power_state)
             if response_data is None:
                 _LOGGER.warning("Function setChromazonePower, parameter %s is not supported", power_state)
                 return False
-            
             new_state = self._get_tzl_power_state(response_data)
             expected_state = (power_state == "ON")
-            
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Úspěšně %s TZL světla%s",
-                    "zapnuto" if power_state == "ON" else "vypnuto",
-                    " (2. pokus)" if is_retry else ""
+                    "Successfully %s TZL lights%s",
+                    "turned on" if power_state == "ON" else "turned off",
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "TZL světla nebyla %s. Očekávaný stav: %s, Aktuální stav: %s%s",
-                    "zapnuto" if power_state == "ON" else "vypnuto",
-                    expected_state,
-                    new_state,
-                    " (2. pokus)" if is_retry else ""
+                    "TZL lights were not %s. Expected: %s, Got: %s%s",
+                    "turned on" if power_state == "ON" else "turned off",
+                    expected_state, new_state,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        """Zapnutí TZL světel."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_tzl_power_state("ON")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout TZL světla")
+                _LOGGER.info("Retrying TZL lights on")
                 success = await self._try_set_tzl_power_state("ON", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning on TZL lights: %s", str(e))
@@ -802,32 +688,26 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
             self._shared_data.resume_updates()
 
     async def async_turn_off(self, **kwargs):
-        """Vypnutí TZL světel."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_tzl_power_state("OFF")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout TZL světla")
+                _LOGGER.info("Retrying TZL lights off")
                 success = await self._try_set_tzl_power_state("OFF", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning off TZL lights: %s", str(e))
         finally:
             self._shared_data.resume_updates()
 
+
 class SpaFilter2Switch(SpaSwitchBase):
-    """Přepínač pro druhý filtr (spa_filter_2)."""
-    
+    """Switch for second filter."""
+
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
-        """Inicializace přepínače druhého filtru."""
         self._shared_data = shared_data
         self._attr_device_info = device_info
-        self._attr_entity_category = EntityCategory.CONFIG  # sekce Nastavení na kartě zařízení
+        self._attr_entity_category = EntityCategory.CONFIG
         self._client = client
         self._attr_unique_id = f"switch.spa_filter_2{unique_id_suffix}"
         self._attr_translation_key = "filter_2"
@@ -836,23 +716,20 @@ class SpaFilter2Switch(SpaSwitchBase):
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
-        
+
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:water-sync"
         else:
             return "mdi:water-remove"
 
     def _get_filter2_state(self, data):
-        """Získá stav druhého filtru z dat."""
         if not data:
             return False
-        # Najít druhý filtr (port "1")
         filter_comp = next(
             (
                 comp
@@ -862,65 +739,52 @@ class SpaFilter2Switch(SpaSwitchBase):
             None,
         )
         if filter_comp:
-            # Pokud je stav "DISABLED", switch je vypnutý, jinak zapnutý
             return filter_comp["value"] != "DISABLED"
         return False
 
     async def async_update(self):
-        """Aktualizace stavu přepínače."""
         data = self._shared_data.data
         if data:
             self._attr_is_on = self._get_filter2_state(data)
             _LOGGER.debug("Updated Filter 2: %s", self._attr_is_on)
 
     async def _try_set_filter2_state(self, state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu druhého filtru s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._client.setFilter2Toggle(state)
             if response_data is None:
                 _LOGGER.warning("Function setFilter2Toggle, parameter %s is not supported", state)
                 return False
-            
             new_state = self._get_filter2_state(response_data)
             expected_state = (state == "ON")
-            
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Úspěšně %s druhý filtr%s",
-                    "zapnuto" if state == "ON" else "vypnuto",
-                    " (2. pokus)" if is_retry else ""
+                    "Successfully %s filter 2%s",
+                    "turned on" if state == "ON" else "turned off",
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Druhý filtr nebyl %s. Očekávaný stav: %s, Aktuální stav: %s%s",
-                    "zapnuto" if state == "ON" else "vypnuto",
-                    expected_state,
-                    new_state,
-                    " (2. pokus)" if is_retry else ""
+                    "Filter 2 was not %s. Expected: %s, Got: %s%s",
+                    "turned on" if state == "ON" else "turned off",
+                    expected_state, new_state,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        """Zapnutí druhého filtru."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_filter2_state("ON")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout druhý filtr")
+                _LOGGER.info("Retrying filter 2 on")
                 success = await self._try_set_filter2_state("ON", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning on filter 2: %s", str(e))
@@ -928,20 +792,97 @@ class SpaFilter2Switch(SpaSwitchBase):
             self._shared_data.resume_updates()
 
     async def async_turn_off(self, **kwargs):
-        """Vypnutí druhého filtru."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_filter2_state("OFF")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout druhý filtr")
+                _LOGGER.info("Retrying filter 2 off")
                 success = await self._try_set_filter2_state("OFF", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning off filter 2: %s", str(e))
+        finally:
+            self._shared_data.resume_updates()
+
+
+class SpaPanelLockSwitch(SpaSwitchBase):
+    """Switch to lock/unlock the physical spa control panel."""
+
+    def __init__(self, shared_data, device_info, unique_id_suffix, client):
+        self._shared_data = shared_data
+        self._attr_device_info = device_info
+        self._client = client
+        self._attr_unique_id = f"switch.spa_panel_lock{unique_id_suffix}"
+        self._attr_translation_key = "panel_lock"
+        self._attr_icon = "mdi:lock"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._is_processing = False
+
+    @property
+    def available(self) -> bool:
+        return not self._is_processing
+
+    @property
+    def icon(self):
+        if self._is_processing:
+            return "mdi:sync"
+        if self.is_on:
+            return "mdi:lock"
+        else:
+            return "mdi:lock-open"
+
+    def _get_panel_lock_state(self, data):
+        """Read panel lock state from spa data payload."""
+        if not data:
+            return False
+        # Uses 'panelLock' flag parsed as a Python boolean by the client object
+        return bool(data.get("panelLock", False))
+
+    async def async_update(self):
+        data = self._shared_data.data
+        if data:
+            self._attr_is_on = self._get_panel_lock_state(data)
+            _LOGGER.debug("Updated Panel Lock: %s", self._attr_is_on)
+
+    async def _try_set_panel_lock(self, locked: bool, is_retry: bool = False) -> bool:
+        """Attempt to set panel lock state with optional retry."""
+        self._is_processing = True
+        self.async_write_ha_state()
+        try:
+            # Pass raw boolean flag (True/False) directly to the wrapper library method
+            response_data = await self._client.setPanelLock(locked)
+            if response_data is None:
+                _LOGGER.warning("setPanelLock(%s) returned None", locked)
+                return False
+            return True
+        finally:
+            self._is_processing = False
+            self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs):
+        """Lock the panel."""
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_panel_lock(True)
+            if not success:
+                _LOGGER.info("Retrying panel lock engage")
+                success = await self._try_set_panel_lock(True, True)
+            await self._shared_data.async_force_update()
+        except Exception as e:
+            _LOGGER.error("Error engaging panel lock: %s", str(e))
+        finally:
+            self._shared_data.resume_updates()
+
+    async def async_turn_off(self, **kwargs):
+        """Unlock the panel."""
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_panel_lock(False)
+            if not success:
+                _LOGGER.info("Retrying panel lock release")
+                success = await self._try_set_panel_lock(False, True)
+            await self._shared_data.async_force_update()
+        except Exception as e:
+            _LOGGER.error("Error releasing panel lock: %s", str(e))
         finally:
             self._shared_data.resume_updates()

--- a/custom_components/control_my_spa/translations/en.json
+++ b/custom_components/control_my_spa/translations/en.json
@@ -599,6 +599,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "panel_lock": {
+        "name": "Panel lock",
+        "state": {
+          "on": "Locked",
+          "off": "Unlocked"
+        }
       }
     },
     "fan": {


### PR DESCRIPTION
This PR adds a SpaPanelLockSwitch entity class to the switch platform, allowing users to safely lock and unlock their physical spa control panels directly from Home Assistant.

Technical Implementation Details:

State Tracking: The feature polls the state via the client's internal parsed data library using the true native boolean data.get("panelLock", False).

Command Payload Execution: Local testing via HTTPS proxy interception confirmed that Balboa's API maps variables via explicit string arguments ("LOCK_PANEL" and "UNLOCK_PANEL"). However, the underlying helper client method setPanelLock(locked) handles this abstraction natively when passed a standard Python boolean flag. Passing explicit text string representations directly into the method wrapper inadvertently triggers a fallback "truthy" validation routine, forcing the tub to lock regardless of intention. Passing a clean, raw boolean True or False ensures bidirectional control executes flawlessly.

Translations: Basic configuration names and English states (Locked / Unlocked) have been explicitly declared inside en.json mapping to the panel_lock translation key - not have not updated other languages.

Verified and working perfectly on local hardware!