### PR TITLE
Migrate pumps from switch to fan entity to support multi-speed presets

### DIFF
--- a/custom_components/control_my_spa/fan.py
+++ b/custom_components/control_my_spa/fan.py
@@ -11,46 +11,41 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     unique_id_suffix = data["unique_id_suffix"]
     client = data["client"]
 
-    if not client.userInfo:
-        _LOGGER.error("Failed to initialize ControlMySpa client (No userInfo)")
-        return False
     if not shared_data.data:
         return False
 
-    # Najít všechny PUMP komponenty s přesně třemi hodnotami (OFF, LOW, HIGH)
+    # Grab all PUMP components from the API payload
     pumps = [
-         component for component in shared_data.data["components"]
-         if component["componentType"] == "PUMP" and 
-         len(component.get("availableValues", [])) >= 2 and
-         any(val in component.get("availableValues", []) for val in ["LOW", "MED"])
+        component for component in shared_data.data["components"]
+        if component["componentType"] == "PUMP"
     ]
 
-    # Logování informací o filtrování
-    # _LOGGER.debug(
-    #     "Filtered components for Fan - Pumps with 3 states: %d",
-    #     len(pumps)
-    # )
+    _LOGGER.debug("Filtered components for Fan - Pumps: %d", len(pumps))
 
-    entities = [SpaPumpFan(shared_data, device_info, unique_id_suffix, pump, len(pumps)) for pump in pumps]
-    
-    async_add_entities(entities, True)
-    _LOGGER.debug("START Fan control_my_spa - no entities created")
+    entities = [SpaPumpFan(shared_data, device_info, pump, len(pumps), unique_id_suffix) for pump in pumps]
 
-    # for entity in entities:
-    #     shared_data.register_subscriber(entity)
-    #     _LOGGER.debug("Created Fan (%s) (%s)", entity._attr_unique_id, entity.entity_id)
+    if entities:
+        async_add_entities(entities, True)
+
+    _LOGGER.debug("START Fan control_my_spa - %d entities created", len(entities))
+
+    for entity in entities:
+        shared_data.register_subscriber(entity)
+
 
 class SpaPumpFan(FanEntity):
-   
-    _attr_has_entity_name = True
-    _attr_supported_features = FanEntityFeature.PRESET_MODE | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+    """Native Fan entity for multi-speed Spa Jets."""
 
-    def __init__(self, shared_data, device_info, unique_id_suffix, pump_data, pump_count):
+    _attr_has_entity_name = True
+
+    def __init__(self, shared_data, device_info, pump_data, pump_count, unique_id_suffix=""):
         self._shared_data = shared_data
         self._pump_data = pump_data
         self._attr_device_info = device_info
-        self._attr_icon = "mdi:fan"
+        # Push-driven via register_subscriber; don't let HA poll on its own timer too.
         self._attr_should_poll = False
+
+        # Configure unique IDs and translation keys to match en.json
         base_id = (
             f"fan.spa_pump"
             if pump_count == 1 or pump_data['port'] is None
@@ -63,362 +58,106 @@ class SpaPumpFan(FanEntity):
             else f"pump_{int(pump_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        
-        # Nastavení preset modes podle dostupných hodnot
-        self._available_values = pump_data.get("availableValues", ["LOW", "HIGH"])
-        # Zjistit, zda je podporován stav OFF
-        self._supports_off = "OFF" in self._available_values
-        # Vytvořit seznam preset modes z dostupných hodnot
-        # OFF nikdy nezobrazovat v seznamu výběru (je dostupný jen přes tlačítko vypnout)
-        if self._supports_off:
-            # Pokud OFF je podporován, zobrazit všechny ostatní stavy
-            preset_modes_list = [val for val in self._available_values if val != "OFF"]
-        else:
-            # Pokud OFF není podporován, LOW reprezentuje vypnutý stav, takže ho také nezobrazovat
-            # V seznamu budou jen aktivní stavy (HIGH, případně MED)
-            preset_modes_list = [val for val in self._available_values if val != "LOW"]
-        self._attr_preset_modes = preset_modes_list
-        self._attr_preset_mode = None
-        self._is_processing = False  # Příznak zpracování
 
-    @property
-    def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
-        return not self._is_processing
+        # Map cloud available values to Fan presets (stripping out "OFF" as a preset)
+        raw_values = pump_data.get("availableValues", ["OFF", "LOW", "HIGH"])
+        self._attr_preset_modes = [val for val in raw_values if val != "OFF"]
 
-    @property
-    def icon(self):
-        if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
-        # Pokud není OFF podporován, LOW reprezentuje vypnutý stav
-        if not self._supports_off and self._attr_preset_mode == "LOW":
-            return "mdi:fan-off"
-        if self._attr_preset_mode == "OFF":
-            return "mdi:fan-off"
-        elif self._attr_preset_mode == "LOW":
-            return "mdi:fan-speed-1"
-        elif self._attr_preset_mode == "MED":
-            return "mdi:fan-speed-2"
-        elif self._attr_preset_mode in ["HIGH", "HI"]:
-            return "mdi:fan-speed-3"
-        else:
-            return "mdi:fan"
+        # Enable Standard On/Off + Presets UI in Home Assistant
+        self._attr_supported_features = (
+            FanEntityFeature.PRESET_MODE |
+            FanEntityFeature.TURN_OFF |
+            FanEntityFeature.TURN_ON
+        )
 
-    @property
-    def is_on(self) -> bool:
-        """Vrátí True pokud není ve stavu OFF (nebo pokud není OFF podporován, pak pokud je HIGH)."""
-        if not self._attr_preset_mode:
-            return False
-        if self._supports_off:
-            return self._attr_preset_mode != "OFF"
-        else:
-            return self._attr_preset_mode in ["HIGH", "HI"]
-
-    def _get_pump_state(self, data):
-        """Získá stav pumpy z dat."""
+    def _get_current_pump_data(self):
+        """Helper to extract live pump state from shared payload."""
+        data = self._shared_data.data
         if not data:
             return None
-        pump = next(
+        return next(
             (comp for comp in data["components"] if comp["componentType"] == "PUMP" and comp["port"] == self._pump_data["port"]),
             None
         )
-        return pump["value"] if pump else None
 
     async def async_update(self):
-        """Aktualizace stavu fan entity."""
-        data = self._shared_data.data
-        if data:
-            pump_state = self._get_pump_state(data)
-            if pump_state is not None:
-                self._attr_preset_mode = pump_state
-            else:
-                # Pokud není OFF podporován, použít LOW jako výchozí stav
-                self._attr_preset_mode = "OFF"
+        """Update Home Assistant state from background cloud payload."""
+        pump = self._get_current_pump_data()
+        if pump:
+            val = pump.get("value", "OFF")
+            self._attr_is_on = (val != "OFF")
+            self._attr_preset_mode = val if val != "OFF" else None
+            _LOGGER.debug("Updated Fan/Pump %s: %s", self._pump_data["port"], val)
+        else:
+            self._attr_is_on = False
+            self._attr_preset_mode = None
 
-    def _get_next_higher_state(self, current_state: str) -> str:
-        """Získá další vyšší stav podle logiky."""
-        available = self._available_values
-        # Pokud není OFF podporován, použít LOW místo OFF
-        off_state = "LOW" if not self._supports_off else "OFF"
-        
-        if current_state == "OFF":
-            # Aktuální stav je OFF, chci zapnout
-            if "LOW" not in available:
-                # Neobsahuje LOW
-                if "MED" not in available:
-                    # Neobsahuje MED → HIGH
-                    return "HIGH" if "HIGH" in available or "HI" in available else off_state
-                else:
-                    # Obsahuje MED → MED
-                    return "MED"
-            else:
-                # Obsahuje LOW → LOW
-                return "LOW"
-        
-        elif current_state == "LOW":
-            # Aktuální stav je LOW, chci vyšší
-            if not self._supports_off:
-                # Pokud není OFF podporován, LOW je nejnižší stav, takže přejít na HIGH
-                return "HIGH" if "HIGH" in available or "HI" in available else "LOW"
-            if "MED" not in available:
-                # Neobsahuje MED
-                if "HIGH" not in available and "HI" not in available:
-                    # Neobsahuje HIGH/HI → OFF
-                    return "OFF"
-                else:
-                    # Obsahuje HIGH → HIGH
-                    return "HIGH" if "HIGH" in available else "HI"
-            else:
-                # Obsahuje MED → MED
-                return "MED"
-        
-        elif current_state == "MED":
-            # Aktuální stav je MED, chci vyšší
-            if "HIGH" not in available and "HI" not in available:
-                # Neobsahuje HIGH → OFF nebo LOW
-                return off_state
-            else:
-                # Obsahuje HIGH → HIGH
-                return "HIGH" if "HIGH" in available else "HI"
-        
-        elif current_state in ["HIGH", "HI"]:
-            # Aktuální stav je HIGH, chci vyšší → cyklické přepínání na OFF nebo LOW
-            return off_state
-        
-        # Výchozí: pokud není rozpoznán stav, vrať OFF nebo LOW
-        return off_state
-
-    def _get_next_lower_state(self, current_state: str) -> str:
-        """Získá další nižší stav podle logiky."""
-        available = self._available_values
-        # Pokud není OFF podporován, použít LOW místo OFF
-        off_state = "LOW" if not self._supports_off else "OFF"
-        
-        if current_state in ["HIGH", "HI"]:
-            # Aktuální stav je HIGH, chci nižší
-            if "MED" in available:
-                return "MED"
-            elif "LOW" in available:
-                return "LOW"
-            else:
-                return off_state
-        
-        elif current_state == "MED":
-            # Aktuální stav je MED, chci nižší
-            if "LOW" in available:
-                return "LOW"
-            else:
-                return off_state
-        
-        elif current_state == "LOW":
-            # Aktuální stav je LOW, chci nižší → OFF nebo zůstat na LOW pokud není OFF podporován
-            if not self._supports_off:
-                # Pokud není OFF podporován, LOW je nejnižší stav
-                return "LOW"
-            return "OFF"
-        
-        # Výchozí: pokud je OFF nebo neznámý stav, vrať OFF nebo LOW
-        return off_state
-
-    async def _try_set_pump_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu pumpy s možností opakování."""
-        self._is_processing = True  # Zneplatnění ovládání
-        self.async_write_ha_state()
-        
+    async def _try_set_pump_state(self, target_state: str, is_retry: bool = False) -> bool:
+        """Push target state directly to the Balboa API and check the instant response."""
         try:
+            device_number = int(self._pump_data["port"])
             response_data = await self._shared_data._client.setJetState(device_number, target_state)
+
             if response_data is None:
-                _LOGGER.warning("Function setJetState, parameter %s is not supported", target_state)
+                _LOGGER.warning("setJetState returned None for target %s", target_state)
                 return False
-            new_state = self._get_pump_state(response_data)
-            
+
+            # Verify the API accepted our change
+            pump = next(
+                (comp for comp in response_data["components"] if comp["componentType"] == "PUMP" and comp["port"] == self._pump_data["port"]),
+                None
+            )
+            new_state = pump["value"] if pump else "OFF"
+
             if new_state == target_state:
-                self._attr_preset_mode = target_state
-                _LOGGER.info(
-                    "Úspěšně nastavena pumpa %s na %s%s",
-                    self._pump_data["port"],
-                    target_state,
-                    " (2. pokus)" if is_retry else ""
-                )
+                self._attr_is_on = (new_state != "OFF")
+                self._attr_preset_mode = new_state if new_state != "OFF" else None
+                _LOGGER.info("Successfully changed pump %s to %s", self._pump_data["port"], target_state)
                 return True
             else:
-                _LOGGER.warning(
-                    "Pump %s was not set. Expected state: %s, Current state: %s%s",
-                    self._pump_data["port"],
-                    target_state,
-                    new_state,
-                    " (2. pokus)" if is_retry else ""
-                )
+                _LOGGER.warning("Pump change rejected or stepped sequentially. Expected: %s, Got: %s", target_state, new_state)
                 return False
         finally:
-            self._is_processing = False  # Obnovení ovládání
+            # Push the (possibly updated) state to HA. No availability toggle,
+            # so the entity never flashes 'unavailable' mid-command.
             self.async_write_ha_state()
 
-    async def async_turn_on(self, speed: str = None, percentage: int = None, preset_mode: str = None, **kwargs):
-        """Zapnutí fan entity."""
-        try:
-            self._shared_data.pause_updates()
-            device_number = int(self._pump_data["port"])
-            
-            # Získat aktuální stav
-            current_state = self._attr_preset_mode or ("LOW" if not self._supports_off else "OFF")
-            
-            # Pokud je zadán preset_mode, použít ho
-            if preset_mode:
-                target_state = preset_mode
-            # Pokud není zadán preset_mode, použít chytrou logiku pro další vyšší stav
-            else:
-                target_state = self._get_next_higher_state(current_state)
-            
-            # Odeslání požadavku
-            success = await self._try_set_pump_state(device_number, target_state)
-            
-            # Aktualizace dat pro ověření stavu
-            await self._shared_data.async_force_update()
-            
-            # Ověření nastavené hodnoty a logování stavu
-            if not success:
-                current_state = self._get_pump_state(self._shared_data.data)
-                if current_state == target_state:
-                    self._attr_preset_mode = target_state
-                    _LOGGER.info(
-                        "Pumpa %s byla nastavena na %s (ověřeno po aktualizaci)",
-                        self._pump_data["port"],
-                        target_state
-                    )
-                else:
-                    _LOGGER.warning(
-                        "Pumpa %s nebyla nastavena. Očekávaný stav: %s, Aktuální stav: %s",
-                        self._pump_data["port"],
-                        target_state,
-                        current_state
-                    )
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
-        except Exception as e:
-            _LOGGER.error("Error turning on pump (port %s): %s", self._pump_data["port"], str(e))
-            raise
-        finally:
-            self._shared_data.resume_updates()
-
-    async def async_turn_off(self, **kwargs):
-        """Vypnutí fan entity."""
-        try:
-            self._shared_data.pause_updates()
-            device_number = int(self._pump_data["port"])
-            
-            # Pokud není OFF podporován, použít LOW místo OFF
-            target_state = "LOW" if not self._supports_off else "OFF"
-            
-            # Odeslání požadavku
-            success = await self._try_set_pump_state(device_number, target_state)
-            
-            # Aktualizace dat pro ověření stavu
-            await self._shared_data.async_force_update()
-            
-            # Ověření nastavené hodnoty a logování stavu
-            if not success:
-                current_state = self._get_pump_state(self._shared_data.data)
-                if current_state == target_state:
-                    self._attr_preset_mode = target_state
-                    _LOGGER.info(
-                        "Pumpa %s byla vypnuta (ověřeno po aktualizaci)",
-                        self._pump_data["port"]
-                    )
-                else:
-                    _LOGGER.warning(
-                        "Pumpa %s nebyla vypnuta. Aktuální stav: %s",
-                        self._pump_data["port"],
-                        current_state
-                    )
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
-        except Exception as e:
-            _LOGGER.error("Error turning off pump (port %s): %s", self._pump_data["port"], str(e))
-            raise
-        finally:
-            self._shared_data.resume_updates()
-
-    def _get_target_state_for_preset(self, current_state: str, desired_preset: str) -> str:
-        """Získá cílový stav pro přechod z aktuálního stavu na požadovaný preset mode."""
-        available = self._available_values
-        
-        # Pokud chceme vypnout, vrať OFF nebo LOW pokud není OFF podporován
-        if desired_preset == "OFF":
-            return "LOW" if not self._supports_off else "OFF"
-        
-        # Pokud je aktuální stav stejný jako požadovaný, vrať aktuální
-        if current_state == desired_preset or (current_state in ["HIGH", "HI"] and desired_preset in ["HIGH", "HI"]):
-            return current_state
-        
-        # Pokud chceme vyšší stav než aktuální
-        if desired_preset in ["HIGH", "HI"]:
-            return self._get_next_higher_state(current_state)
-        elif desired_preset == "MED":
-            # Pokud chceme MED a aktuálně jsme na nižší úrovni, použij chytrou logiku pro vyšší
-            if current_state == "OFF" or current_state == "LOW":
-                return self._get_next_higher_state(current_state)
-            # Pokud jsme na vyšší úrovni a chceme MED, vrať MED přímo
-            elif current_state in ["HIGH", "HI"]:
-                return "MED" if "MED" in available else self._get_next_lower_state(current_state)
-            else:
-                return "MED"
-        elif desired_preset == "LOW":
-            # Pokud chceme LOW a aktuálně jsme OFF, použij chytrou logiku pro zapnutí
-            if current_state == "OFF":
-                return self._get_next_higher_state(current_state)
-            # Pokud jsme na vyšší úrovni a chceme LOW, vrať LOW přímo
-            elif current_state in ["HIGH", "HI", "MED"]:
-                return "LOW" if "LOW" in available else self._get_next_lower_state(current_state)
-            else:
-                return "LOW"
-        
-        # Výchozí: vrať požadovaný preset_mode
-        return desired_preset
-
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        """Nastavení preset mode."""
+        """HA Interface: User selected a specific speed (LOW or HIGH) from dashboard."""
         if preset_mode not in self._attr_preset_modes:
-            _LOGGER.warning("Invalid preset mode: %s", preset_mode)
+            _LOGGER.error("Invalid preset mode %s selected", preset_mode)
             return
-        
+
         try:
             self._shared_data.pause_updates()
-            device_number = int(self._pump_data["port"])
-            
-            # Získat aktuální stav
-            current_state = self._attr_preset_mode or ("LOW" if not self._supports_off else "OFF")
-            
-            # Určit cílový stav podle chytré logiky
-            target_state = self._get_target_state_for_preset(current_state, preset_mode)
-            
-            # Odeslání požadavku
-            success = await self._try_set_pump_state(device_number, target_state)
-            
-            # Aktualizace dat pro ověření stavu
-            await self._shared_data.async_force_update()
-            
-            # Ověření nastavené hodnoty a logování stavu
+            success = await self._try_set_pump_state(preset_mode)
             if not success:
-                current_state = self._get_pump_state(self._shared_data.data)
-                if current_state == target_state:
-                    self._attr_preset_mode = target_state
-                    _LOGGER.info(
-                        "Pumpa %s byla nastavena na %s (ověřeno po aktualizaci)",
-                        self._pump_data["port"],
-                        target_state
-                    )
-                else:
-                    _LOGGER.warning(
-                        "Pumpa %s nebyla nastavena. Očekávaný stav: %s, Aktuální stav: %s",
-                        self._pump_data["port"],
-                        target_state,
-                        current_state
-                    )
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
-        except Exception as e:
-            _LOGGER.error("Error setting preset mode for pump (port %s): %s", self._pump_data["port"], str(e))
-            raise
+                await self._try_set_pump_state(preset_mode, True)
+            await self._shared_data.async_force_update()
+        finally:
+            self._shared_data.resume_updates()
+
+    async def async_turn_on(self, percentage=None, preset_mode=None, **kwargs) -> None:
+        """HA Interface: User clicked the primary Turn On toggle."""
+        # Default to the HIGHEST speed if turned on generically (full jets).
+        target = preset_mode if preset_mode else (self._attr_preset_modes[-1] if self._attr_preset_modes else "HIGH")
+
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_pump_state(target)
+            if not success:
+                await self._try_set_pump_state(target, True)
+            await self._shared_data.async_force_update()
+        finally:
+            self._shared_data.resume_updates()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """HA Interface: User clicked the primary Turn Off toggle."""
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_pump_state("OFF")
+            if not success:
+                await self._try_set_pump_state("OFF", True)
+            await self._shared_data.async_force_update()
         finally:
             self._shared_data.resume_updates()

--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -835,7 +835,7 @@ class SpaPanelLockSwitch(SpaSwitchBase):
         """Read panel lock state from spa data payload."""
         if not data:
             return False
-        return bool(data.get("panelLock", False))
+        return bool(data.get("isPanelLocked", False))
 
     async def async_update(self):
         data = self._shared_data.data

--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -835,7 +835,6 @@ class SpaPanelLockSwitch(SpaSwitchBase):
         """Read panel lock state from spa data payload."""
         if not data:
             return False
-        # Uses 'panelLock' flag parsed as a Python boolean by the client object
         return bool(data.get("panelLock", False))
 
     async def async_update(self):
@@ -845,16 +844,33 @@ class SpaPanelLockSwitch(SpaSwitchBase):
             _LOGGER.debug("Updated Panel Lock: %s", self._attr_is_on)
 
     async def _try_set_panel_lock(self, locked: bool, is_retry: bool = False) -> bool:
-        """Attempt to set panel lock state with optional retry."""
+        """Attempt to set panel lock state with response verification."""
         self._is_processing = True
         self.async_write_ha_state()
         try:
-            # Pass raw boolean flag (True/False) directly to the wrapper library method
             response_data = await self._client.setPanelLock(locked)
             if response_data is None:
                 _LOGGER.warning("setPanelLock(%s) returned None", locked)
                 return False
-            return True
+            
+            # ACK Check: Read the server response payload to ensure state changed successfully
+            new_state = self._get_panel_lock_state(response_data)
+            if new_state == locked:
+                self._attr_is_on = new_state
+                _LOGGER.info(
+                    "Successfully %s panel lock%s",
+                    "engaged" if locked else "released",
+                    " (retry)" if is_retry else ""
+                )
+                return True
+            else:
+                _LOGGER.warning(
+                    "Panel lock modification rejected by cloud endpoint. Expected: %s, Got: %s%s",
+                    locked,
+                    new_state,
+                    " (retry)" if is_retry else ""
+                )
+                return False
         finally:
             self._is_processing = False
             self.async_write_ha_state()

--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -2,6 +2,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
 from .const import DOMAIN
 import logging
+import asyncio
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -134,20 +136,20 @@ class SpaLightSwitch(SpaSwitchBase):
             if new_state == target_state:
                 self._attr_is_on = (target_state == self._on_value)
                 _LOGGER.info(
-                    "Successfully %s light %s%s",
-                    "turned on" if target_state == self._on_value else "turned off",
+                    "Úspěšně %s světlo %s%s",
+                    "zapnuto" if target_state == self._on_value else "vypnuto",
                     self._light_data["port"],
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Light %s was not %s. Expected: %s, Got: %s%s",
+                    "Light %s was not %s. Expected state: %s, Current state: %s%s",
                     self._light_data["port"],
-                    "turned on" if target_state == self._on_value else "turned off",
+                    "zapnuto" if target_state == self._on_value else "vypnuto",
                     target_state,
                     new_state,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -160,10 +162,10 @@ class SpaLightSwitch(SpaSwitchBase):
             device_number = int(self._light_data["port"])
             success = await self._try_set_light_state(device_number, self._on_value)
             if not success:
-                _LOGGER.info("Retrying light on %s", self._light_data["port"])
+                _LOGGER.info("Zkouším znovu zapnout světlo %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._on_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on light (port %s): %s", self._light_data["port"], str(e))
@@ -177,10 +179,10 @@ class SpaLightSwitch(SpaSwitchBase):
             device_number = int(self._light_data["port"])
             success = await self._try_set_light_state(device_number, self._off_value)
             if not success:
-                _LOGGER.info("Retrying light off %s", self._light_data["port"])
+                _LOGGER.info("Zkouším znovu vypnout světlo %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._off_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off light (port %s): %s", self._light_data["port"], str(e))
@@ -275,20 +277,20 @@ class SpaPumpSwitch(SpaSwitchBase):
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Successfully %s pump %s%s",
-                    "turned on" if expected_is_on else "turned off",
+                    "Úspěšně %s čerpadlo %s%s",
+                    "zapnuto" if expected_is_on else "vypnuto",
                     self._pump_data["port"],
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
+                    "Pump %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
                     self._pump_data["port"],
-                    "turned on" if expected_is_on else "turned off",
+                    "zapnuto" if expected_is_on else "vypnuto",
                     target_state, expected_is_on,
                     new_state, actual_is_on,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -301,10 +303,10 @@ class SpaPumpSwitch(SpaSwitchBase):
             device_number = int(self._pump_data["port"])
             success = await self._try_set_pump_state(device_number, self._on_value)
             if not success:
-                _LOGGER.info("Retrying pump on %s", self._pump_data["port"])
+                _LOGGER.info("Zkouším znovu zapnout čerpadlo %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._on_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on pump (port %s): %s", self._pump_data["port"], str(e))
@@ -318,10 +320,10 @@ class SpaPumpSwitch(SpaSwitchBase):
             device_number = int(self._pump_data["port"])
             success = await self._try_set_pump_state(device_number, self._off_value)
             if not success:
-                _LOGGER.info("Retrying pump off %s", self._pump_data["port"])
+                _LOGGER.info("Zkouším znovu vypnout čerpadlo %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._off_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off pump (port %s): %s", self._pump_data["port"], str(e))
@@ -411,20 +413,20 @@ class SpaPumpLowSwitch(SpaSwitchBase):
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Successfully %s pump low %s%s",
-                    "turned on" if expected_is_on else "turned off",
+                    "Úspěšně %s čerpadlo Low %s%s",
+                    "zapnuto" if expected_is_on else "vypnuto",
                     self._pump_data["port"],
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump Low %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
+                    "Pump Low %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
                     self._pump_data["port"],
-                    "turned on" if expected_is_on else "turned off",
+                    "zapnuto" if expected_is_on else "vypnuto",
                     target_state, expected_is_on,
                     new_state, actual_is_on,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -437,12 +439,12 @@ class SpaPumpLowSwitch(SpaSwitchBase):
             device_number = int(self._pump_data["port"])
             success = await self._try_set_pump_state(device_number, self._on_value)
             if not success:
-                _LOGGER.info("First attempt to turn on pump low %s failed", self._pump_data["port"])
+                _LOGGER.info("První pokus o zapnutí čerpadla Low %s selhal", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError:
-            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
+        except ValueError as ve:
+            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning on pump low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning on pump Low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
@@ -453,12 +455,12 @@ class SpaPumpLowSwitch(SpaSwitchBase):
             device_number = int(self._pump_data["port"])
             success = await self._try_set_pump_state(device_number, self._off_value)
             if not success:
-                _LOGGER.info("First attempt to turn off pump low %s failed", self._pump_data["port"])
+                _LOGGER.info("První pokus o vypnutí čerpadla Low %s selhal", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError:
-            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
+        except ValueError as ve:
+            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning off pump low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning off pump Low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
@@ -550,20 +552,20 @@ class SpaBlowerSwitch(SpaSwitchBase):
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Successfully %s blower %s%s",
-                    "turned on" if expected_is_on else "turned off",
+                    "Úspěšně %s vzduchovač %s%s",
+                    "zapnut" if expected_is_on else "vypnut",
                     self._blower_data["port"],
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Blower %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
+                    "Blower %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
                     self._blower_data["port"],
-                    "turned on" if expected_is_on else "turned off",
+                    "zapnut" if expected_is_on else "vypnut",
                     target_state, expected_is_on,
                     new_state, actual_is_on,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -576,10 +578,10 @@ class SpaBlowerSwitch(SpaSwitchBase):
             device_number = int(self._blower_data["port"])
             success = await self._try_set_blower_state(device_number, self._on_value)
             if not success:
-                _LOGGER.info("Retrying blower on %s", self._blower_data["port"])
+                _LOGGER.info("Zkouším znovu zapnout vzduchovač %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._on_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on blower (port %s): %s", self._blower_data["port"], str(e))
@@ -593,10 +595,10 @@ class SpaBlowerSwitch(SpaSwitchBase):
             device_number = int(self._blower_data["port"])
             success = await self._try_set_blower_state(device_number, self._off_value)
             if not success:
-                _LOGGER.info("Retrying blower off %s", self._blower_data["port"])
+                _LOGGER.info("Zkouším znovu vypnout vzduchovač %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._off_value, True)
             await self._shared_data.async_force_update()
-        except ValueError:
+        except ValueError as ve:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off blower (port %s): %s", self._blower_data["port"], str(e))
@@ -606,8 +608,6 @@ class SpaBlowerSwitch(SpaSwitchBase):
 
 
 class SpaTzlPowerSwitch(SpaSwitchBase):
-    """Switch for TZL/Chromazone lighting power."""
-
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
         self._shared_data = shared_data
         self._attr_device_info = device_info
@@ -657,17 +657,17 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Successfully %s TZL lights%s",
-                    "turned on" if power_state == "ON" else "turned off",
-                    " (retry)" if is_retry else ""
+                    "Úspěšně %s TZL světla%s",
+                    "zapnuto" if power_state == "ON" else "vypnuto",
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "TZL lights were not %s. Expected: %s, Got: %s%s",
-                    "turned on" if power_state == "ON" else "turned off",
+                    "TZL světla nebyla %s. Očekávaný stav: %s, Aktuální stav: %s%s",
+                    "zapnuto" if power_state == "ON" else "vypnuto",
                     expected_state, new_state,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -679,7 +679,7 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
             self._shared_data.pause_updates()
             success = await self._try_set_tzl_power_state("ON")
             if not success:
-                _LOGGER.info("Retrying TZL lights on")
+                _LOGGER.info("Zkouším znovu zapnout TZL světla")
                 success = await self._try_set_tzl_power_state("ON", True)
             await self._shared_data.async_force_update()
         except Exception as e:
@@ -692,7 +692,7 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
             self._shared_data.pause_updates()
             success = await self._try_set_tzl_power_state("OFF")
             if not success:
-                _LOGGER.info("Retrying TZL lights off")
+                _LOGGER.info("Zkouším znovu vypnout TZL světla")
                 success = await self._try_set_tzl_power_state("OFF", True)
             await self._shared_data.async_force_update()
         except Exception as e:
@@ -702,8 +702,6 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
 
 
 class SpaFilter2Switch(SpaSwitchBase):
-    """Switch for second filter."""
-
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
         self._shared_data = shared_data
         self._attr_device_info = device_info
@@ -761,17 +759,17 @@ class SpaFilter2Switch(SpaSwitchBase):
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Successfully %s filter 2%s",
-                    "turned on" if state == "ON" else "turned off",
-                    " (retry)" if is_retry else ""
+                    "Úspěšně %s druhý filtr%s",
+                    "zapnuto" if state == "ON" else "vypnuto",
+                    " (2. pokus)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Filter 2 was not %s. Expected: %s, Got: %s%s",
-                    "turned on" if state == "ON" else "turned off",
+                    "Druhý filtr nebyl %s. Očekávaný stav: %s, Aktuální stav: %s%s",
+                    "zapnuto" if state == "ON" else "vypnuto",
                     expected_state, new_state,
-                    " (retry)" if is_retry else ""
+                    " (2. pokus)" if is_retry else ""
                 )
                 return False
         finally:
@@ -783,7 +781,7 @@ class SpaFilter2Switch(SpaSwitchBase):
             self._shared_data.pause_updates()
             success = await self._try_set_filter2_state("ON")
             if not success:
-                _LOGGER.info("Retrying filter 2 on")
+                _LOGGER.info("Zkouším znovu zapnout druhý filtr")
                 success = await self._try_set_filter2_state("ON", True)
             await self._shared_data.async_force_update()
         except Exception as e:
@@ -796,7 +794,7 @@ class SpaFilter2Switch(SpaSwitchBase):
             self._shared_data.pause_updates()
             success = await self._try_set_filter2_state("OFF")
             if not success:
-                _LOGGER.info("Retrying filter 2 off")
+                _LOGGER.info("Zkouším znovu vypnout druhý filtr")
                 success = await self._try_set_filter2_state("OFF", True)
             await self._shared_data.async_force_update()
         except Exception as e:
@@ -816,73 +814,41 @@ class SpaPanelLockSwitch(SpaSwitchBase):
         self._attr_translation_key = "panel_lock"
         self._attr_icon = "mdi:lock"
         self._attr_entity_category = EntityCategory.CONFIG
-        self._is_processing = False
+        self._attr_should_poll = False
+        self._attr_is_on = False
+        self._optimistic_until = 0
+        self.entity_id = "switch.spa_panel_lock"
 
     @property
-    def available(self) -> bool:
-        return not self._is_processing
+    def is_on(self):
+        return self._attr_is_on
 
     @property
-    def icon(self):
-        if self._is_processing:
-            return "mdi:sync"
-        if self.is_on:
-            return "mdi:lock"
-        else:
-            return "mdi:lock-open"
+    def assumed_state(self) -> bool:
+        return True
 
     def _get_panel_lock_state(self, data):
-        """Read panel lock state from spa data payload."""
         if not data:
             return False
-        return bool(data.get("isPanelLocked", False))
+        return bool(data.get("panelLock", False))
 
     async def async_update(self):
+        if time.time() < self._optimistic_until:
+            _LOGGER.debug("Panel lock in optimistic guard window; skipping state overwrite.")
+            return
         data = self._shared_data.data
         if data:
             self._attr_is_on = self._get_panel_lock_state(data)
             _LOGGER.debug("Updated Panel Lock: %s", self._attr_is_on)
 
-    async def _try_set_panel_lock(self, locked: bool, is_retry: bool = False) -> bool:
-        """Attempt to set panel lock state with response verification."""
-        self._is_processing = True
-        self.async_write_ha_state()
-        try:
-            response_data = await self._client.setPanelLock(locked)
-            if response_data is None:
-                _LOGGER.warning("setPanelLock(%s) returned None", locked)
-                return False
-            
-            # ACK Check: Read the server response payload to ensure state changed successfully
-            new_state = self._get_panel_lock_state(response_data)
-            if new_state == locked:
-                self._attr_is_on = new_state
-                _LOGGER.info(
-                    "Successfully %s panel lock%s",
-                    "engaged" if locked else "released",
-                    " (retry)" if is_retry else ""
-                )
-                return True
-            else:
-                _LOGGER.warning(
-                    "Panel lock modification rejected by cloud endpoint. Expected: %s, Got: %s%s",
-                    locked,
-                    new_state,
-                    " (retry)" if is_retry else ""
-                )
-                return False
-        finally:
-            self._is_processing = False
-            self.async_write_ha_state()
-
     async def async_turn_on(self, **kwargs):
         """Lock the panel."""
+        self._attr_is_on = True
+        self._optimistic_until = time.time() + 22
+        self.async_write_ha_state()
         try:
             self._shared_data.pause_updates()
-            success = await self._try_set_panel_lock(True)
-            if not success:
-                _LOGGER.info("Retrying panel lock engage")
-                success = await self._try_set_panel_lock(True, True)
+            await self._client.setPanelLock(True)
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error engaging panel lock: %s", str(e))
@@ -891,12 +857,12 @@ class SpaPanelLockSwitch(SpaSwitchBase):
 
     async def async_turn_off(self, **kwargs):
         """Unlock the panel."""
+        self._attr_is_on = False
+        self._optimistic_until = time.time() + 22
+        self.async_write_ha_state()
         try:
             self._shared_data.pause_updates()
-            success = await self._try_set_panel_lock(False)
-            if not success:
-                _LOGGER.info("Retrying panel lock release")
-                success = await self._try_set_panel_lock(False, True)
+            await self._client.setPanelLock(False)
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error releasing panel lock: %s", str(e))

--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -1,4 +1,3 @@
-from ast import Await
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import EntityCategory
 from .const import DOMAIN
@@ -19,36 +18,24 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     if not shared_data.data:
         return False
 
-    # Najít všechny LIGHT komponenty s přesně dvěma hodnotami
     lights = [
         component for component in shared_data.data["components"]
-        if component["componentType"] == "LIGHT" and 
+        if component["componentType"] == "LIGHT" and
         len(component.get("availableValues", ["OFF", "HIGH"])) == 2
     ]
-    # Najít všechny PUMP komponenty s přesně dvěma hodnotami
     pumps = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "PUMP"
     ]
-    # Najít všechny BLOWER komponenty
     blowers = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "BLOWER"
     ]
-    # Najít všechny FILTER komponenty
     filters = [
         component for component in shared_data.data["components"]
         if component["componentType"] == "FILTER"
     ]
-    # Najít všechny PUMP komponenty s LOW nebo MED hodnotami (pro SpaPumpLowSwitch)
-    # pumps_low = [
-    #     component for component in shared_data.data["components"]
-    #     if component["componentType"] == "PUMP" and
-    #     len(component.get("availableValues", [])) >= 2 and
-    #     any(val in component.get("availableValues", []) for val in ["LOW", "MED"])
-    # ]
 
-    # Logování informací o filtrování
     _LOGGER.debug(
         "Filtered components for Switch - Lights: %d, Pumps: %d, Pumps Low: %d, Blowers: %d, Filters: %d",
         len(lights),
@@ -60,18 +47,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = [SpaLightSwitch(shared_data, device_info, unique_id_suffix, light, len(lights)) for light in lights]
     entities += [SpaPumpSwitch(shared_data, device_info, pump, len(pumps), unique_id_suffix) for pump in pumps]
-    # entities += [SpaPumpLowSwitch(shared_data, device_info, pump, len(pumps_low), unique_id_suffix) for pump in pumps_low]
     entities += [SpaBlowerSwitch(shared_data, device_info, unique_id_suffix, blower, len(blowers)) for blower in blowers]
-    
-    # Přidání switch pro druhý filtr pouze pokud existují dva filtry
+
     if len(filters) >= 2:
         entities.append(SpaFilter2Switch(shared_data, device_info, unique_id_suffix, client))
-    
-    # Přidání TZL přepínače pouze pokud jsou k dispozici TZL zóny
+
     tzl_zones = shared_data.data.get("tzlZones", [])
     if tzl_zones:
         entities.append(SpaTzlPowerSwitch(shared_data, device_info, unique_id_suffix, client))
-    
+
+    entities.append(SpaPanelLockSwitch(shared_data, device_info, unique_id_suffix, client))
+
     async_add_entities(entities, True)
     _LOGGER.debug("START Switch control_my_spa")
 
@@ -79,8 +65,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         shared_data.register_subscriber(entity)
         _LOGGER.debug("Created Switch (%s) (%s)", entity._attr_unique_id, entity.entity_id)
 
+
 class SpaSwitchBase(SwitchEntity):
     _attr_has_entity_name = True
+
 
 class SpaLightSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, unique_id_suffix, light_data, light_count):
@@ -97,28 +85,25 @@ class SpaLightSwitch(SpaSwitchBase):
         self._attr_unique_id = f"{base_id}{unique_id_suffix}"
         self._attr_translation_key = f"light" if light_count == 1 or light_data['port'] == None else f"light_{int(light_data['port']) + 1}"
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro světlo, výchozí hodnoty jsou OFF a HIGH
         self._available_values = light_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = self._available_values[0]  # První hodnota pro vypnuto
-        self._on_value = self._available_values[-1]  # Poslední hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = self._available_values[0]
+        self._on_value = self._available_values[-1]
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:lightbulb-on"
         else:
             return "mdi:lightbulb"
 
     def _get_light_state(self, data):
-        """Získá stav světla z dat."""
         if not data:
             return None
         light = next(
@@ -138,55 +123,47 @@ class SpaLightSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_light_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu světla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setLightState(device_number, target_state)
             if response_data is None:
                 _LOGGER.warning("Function setLightState, parameter %s is not supported", target_state)
                 return False
             new_state = self._get_light_state(response_data)
-            
             if new_state == target_state:
                 self._attr_is_on = (target_state == self._on_value)
                 _LOGGER.info(
-                    "Úspěšně %s světlo %s%s",
-                    "zapnuto" if target_state == self._on_value else "vypnuto",
+                    "Successfully %s light %s%s",
+                    "turned on" if target_state == self._on_value else "turned off",
                     self._light_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Light %s was not %s. Expected state: %s, Current state: %s%s",
+                    "Light %s was not %s. Expected: %s, Got: %s%s",
                     self._light_data["port"],
-                    "zapnuto" if target_state == self._on_value else "vypnuto",
+                    "turned on" if target_state == self._on_value else "turned off",
                     target_state,
                     new_state,
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._light_data["port"])
-            
-            # První pokus
             success = await self._try_set_light_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout světlo %s", self._light_data["port"])
+                _LOGGER.info("Retrying light on %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on light (port %s): %s", self._light_data["port"], str(e))
@@ -198,23 +175,19 @@ class SpaLightSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._light_data["port"])
-            
-            # První pokus
             success = await self._try_set_light_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout světlo %s", self._light_data["port"])
+                _LOGGER.info("Retrying light off %s", self._light_data["port"])
                 success = await self._try_set_light_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for light: %s", self._light_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off light (port %s): %s", self._light_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaPumpSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, pump_data, pump_count, unique_id_suffix=""):
@@ -235,42 +208,34 @@ class SpaPumpSwitch(SpaSwitchBase):
             else f"pump_{int(pump_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro pump, výchozí hodnoty jsou OFF a HIGH
         self._available_values = pump_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = "OFF"  # Pevná hodnota pro vypnuto
-        self._on_value = "HIGH"  # Pevná hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = "OFF"
+        self._on_value = "HIGH"
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-windy"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota 'LOW'
         if value == "LOW":
-            # Pokud mezi dostupnými není MED ani HIGH ani HI → nastav OFF
             if "MED" not in self._available_values and "HIGH" not in self._available_values and "HI" not in self._available_values:
                 return True
-            # Pokud není MED, ale je HIGH → nastav HIGH
             elif "MED" not in self._available_values and ("HIGH" in self._available_values or "HI" in self._available_values):
                 return False
-            # Pokud je MED → nastav MED
             elif "MED" in self._available_values:
                 return False
             else:
                 return True
-        # Pokud je hodnota 'MED', ověřit zda je HIGH v availableValues
         elif value == "MED":
             if "HIGH" in self._available_values:
                 return False
@@ -293,10 +258,8 @@ class SpaPumpSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_pump_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu čerpadla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setJetState(device_number, target_state)
             if response_data is None:
@@ -307,51 +270,41 @@ class SpaPumpSwitch(SpaSwitchBase):
                 None
             )
             new_state = pump["value"] if pump else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s čerpadlo %s%s",
-                    "zapnuto" if expected_is_on else "vypnuto",
+                    "Successfully %s pump %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._pump_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Pump %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._pump_data["port"],
-                    "zapnuto" if expected_is_on else "vypnuto",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout čerpadlo %s", self._pump_data["port"])
+                _LOGGER.info("Retrying pump on %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on pump (port %s): %s", self._pump_data["port"], str(e))
@@ -363,23 +316,19 @@ class SpaPumpSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout čerpadlo %s", self._pump_data["port"])
+                _LOGGER.info("Retrying pump off %s", self._pump_data["port"])
                 success = await self._try_set_pump_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for pump: %s", self._pump_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off pump (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaPumpLowSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, pump_data, pump_count, unique_id_suffix=""):
@@ -400,41 +349,35 @@ class SpaPumpLowSwitch(SpaSwitchBase):
             else f"low_pump_{int(pump_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro pump, výchozí hodnoty jsou OFF a HIGH
         self._available_values = pump_data.get("availableValues", ["LOW", "HIGH"])
-        # Nastavení _off_value: LOW má nižší stav, pokud tam je MED
         if "LOW" in self._available_values:
             self._off_value = "LOW"
         elif "MED" in self._available_values:
             self._off_value = "MED"
         else:
             self._off_value = self._available_values[0] if self._available_values else "OFF"
-        # Nastavení _on_value: nejvyšší dostupná hodnota z MED nebo HIGH
         if "HIGH" in self._available_values or "HI" in self._available_values:
             self._on_value = "HIGH"
         elif "MED" in self._available_values:
             self._on_value = "MED"
         else:
             self._on_value = self._available_values[-1] if self._available_values else "HIGH"
-        self._is_processing = False  # Příznak zpracování
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-windy"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota rovna _on_value (HIGH nebo MED), pak je to ON
         return value == self._on_value
 
     async def async_update(self):
@@ -451,68 +394,55 @@ class SpaPumpLowSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_pump_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu čerpadla s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setJetState(device_number, target_state)
             if response_data is None:
                 _LOGGER.warning("Function setJetState, parameter %s is not supported", target_state)
                 return False
-
             pump = next(
                 (comp for comp in response_data["components"] if comp["componentType"] == "PUMP" and comp["port"] == self._pump_data["port"]),
                 None
             )
             new_state = pump["value"] if pump else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s čerpadlo Low %s%s",
-                    "zapnuto" if expected_is_on else "vypnuto",
+                    "Successfully %s pump low %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._pump_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Pump Low %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Pump Low %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._pump_data["port"],
-                    "zapnuto" if expected_is_on else "vypnuto",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._on_value)
-            
-            # Logování pokud první pokus selhal (bez druhého pokusu)
             if not success:
-                _LOGGER.info("První pokus o zapnutí čerpadla Low %s selhal", self._pump_data["port"])
-                
+                _LOGGER.info("First attempt to turn on pump low %s failed", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
+        except ValueError:
+            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning on pump Low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning on pump low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
@@ -521,22 +451,18 @@ class SpaPumpLowSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._pump_data["port"])
-            
-            # První pokus
             success = await self._try_set_pump_state(device_number, self._off_value)
-            
-            # Logování pokud první pokus selhal (bez druhého pokusu)
             if not success:
-                _LOGGER.info("První pokus o vypnutí čerpadla Low %s selhal", self._pump_data["port"])
-                
+                _LOGGER.info("First attempt to turn off pump low %s failed", self._pump_data["port"])
             await self._shared_data.async_force_update()
-        except ValueError as ve:
-            _LOGGER.error("Invalid port value for pump Low: %s", self._pump_data["port"])
+        except ValueError:
+            _LOGGER.error("Invalid port value for pump low: %s", self._pump_data["port"])
         except Exception as e:
-            _LOGGER.error("Error turning off pump Low (port %s): %s", self._pump_data["port"], str(e))
+            _LOGGER.error("Error turning off pump low (port %s): %s", self._pump_data["port"], str(e))
             raise
         finally:
             self._shared_data.resume_updates()
+
 
 class SpaBlowerSwitch(SpaSwitchBase):
     def __init__(self, shared_data, device_info, unique_id_suffix, blower_data, blower_count):
@@ -557,42 +483,34 @@ class SpaBlowerSwitch(SpaSwitchBase):
             else f"blower_{int(blower_data['port']) + 1}"
         )
         self.entity_id = self._attr_unique_id
-        # Získání dostupných hodnot pro blower, výchozí hodnoty jsou OFF a HIGH
         self._available_values = blower_data.get("availableValues", ["OFF", "HIGH"])
-        self._off_value = "OFF"  # Pevná hodnota pro vypnuto
-        self._on_value = "HIGH"  # Pevná hodnota pro zapnuto
-        self._is_processing = False  # Příznak zpracování
+        self._off_value = "OFF"
+        self._on_value = "HIGH"
+        self._is_processing = False
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
 
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         else:
             return "mdi:weather-dust"
 
     def _calculate_is_on_state(self, value: str) -> bool:
-        """Vypočítá stav is_on na základě hodnoty podle pravidel."""
         if not value:
             return False
-        # Pokud je hodnota 'LOW'
         if value == "LOW":
-            # Pokud mezi dostupnými není MED ani HIGH ani HI → nastav OFF
             if "MED" not in self._available_values and "HIGH" not in self._available_values and "HI" not in self._available_values:
                 return False
-            # Pokud není MED, ale je HIGH → nastav HIGH
             elif "MED" not in self._available_values and ("HIGH" in self._available_values or "HI" in self._available_values):
                 return True
-            # Pokud je MED → nastav MED
             elif "MED" in self._available_values:
                 return True
             else:
                 return False
-        # Pokud je hodnota 'MED', ověřit zda je HIGH v availableValues
         elif value == "MED":
             if "HIGH" in self._available_values:
                 return True
@@ -615,10 +533,8 @@ class SpaBlowerSwitch(SpaSwitchBase):
                 self._attr_is_on = False
 
     async def _try_set_blower_state(self, device_number: int, target_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu vzduchovače s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._shared_data._client.setBlowerState(device_number, target_state)
             if response_data is None:
@@ -629,51 +545,41 @@ class SpaBlowerSwitch(SpaSwitchBase):
                 None
             )
             new_state = blower["value"] if blower else None
-            
-            # Převést stavy na boolean hodnoty
             expected_is_on = self._calculate_is_on_state(target_state)
             actual_is_on = self._calculate_is_on_state(new_state) if new_state else False
-            
             if expected_is_on == actual_is_on:
                 self._attr_is_on = actual_is_on
                 _LOGGER.info(
-                    "Úspěšně %s vzduchovač %s%s",
-                    "zapnut" if expected_is_on else "vypnut",
+                    "Successfully %s blower %s%s",
+                    "turned on" if expected_is_on else "turned off",
                     self._blower_data["port"],
-                    " (2. pokus)" if is_retry else ""
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Blower %s was not %s. Expected state: %s (%s), Current state: %s (%s)%s",
+                    "Blower %s was not %s. Expected: %s (%s), Got: %s (%s)%s",
                     self._blower_data["port"],
-                    "zapnut" if expected_is_on else "vypnut",
-                    target_state,
-                    expected_is_on,
-                    new_state,
-                    actual_is_on,
-                    " (2. pokus)" if is_retry else ""
+                    "turned on" if expected_is_on else "turned off",
+                    target_state, expected_is_on,
+                    new_state, actual_is_on,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._blower_data["port"])
-            
-            # První pokus
             success = await self._try_set_blower_state(device_number, self._on_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout vzduchovač %s", self._blower_data["port"])
+                _LOGGER.info("Retrying blower on %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._on_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning on blower (port %s): %s", self._blower_data["port"], str(e))
@@ -685,17 +591,12 @@ class SpaBlowerSwitch(SpaSwitchBase):
         try:
             self._shared_data.pause_updates()
             device_number = int(self._blower_data["port"])
-            
-            # První pokus
             success = await self._try_set_blower_state(device_number, self._off_value)
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout vzduchovač %s", self._blower_data["port"])
+                _LOGGER.info("Retrying blower off %s", self._blower_data["port"])
                 success = await self._try_set_blower_state(device_number, self._off_value, True)
-                
             await self._shared_data.async_force_update()
-        except ValueError as ve:
+        except ValueError:
             _LOGGER.error("Invalid port value for blower: %s", self._blower_data["port"])
         except Exception as e:
             _LOGGER.error("Error turning off blower (port %s): %s", self._blower_data["port"], str(e))
@@ -703,11 +604,11 @@ class SpaBlowerSwitch(SpaSwitchBase):
         finally:
             self._shared_data.resume_updates()
 
+
 class SpaTzlPowerSwitch(SpaSwitchBase):
-    """Přepínač pro zapnutí/vypnutí TZL světel."""
+    """Switch for TZL/Chromazone lighting power."""
 
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
-        """Inicializace TZL přepínače."""
         self._shared_data = shared_data
         self._attr_device_info = device_info
         self._client = client
@@ -718,83 +619,68 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
-        
+
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:lightbulb-group"
         else:
             return "mdi:lightbulb-group-off"
 
     def _get_tzl_power_state(self, data):
-        """Získá stav TZL světel z dat."""
         if not data:
             return False
         tzl_zones = data.get("tzlZones", [])
         if not tzl_zones:
             return False
-        # Přepínač je ON, pokud alespoň jedna zóna není ve stavu OFF
         return any(zone.get("state") != "OFF" for zone in tzl_zones)
 
     async def async_update(self):
-        """Aktualizace stavu přepínače."""
         data = self._shared_data.data
         if data:
             self._attr_is_on = self._get_tzl_power_state(data)
             _LOGGER.debug("Updated TZL Power: %s", self._attr_is_on)
 
     async def _try_set_tzl_power_state(self, power_state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu TZL světel s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._client.setChromazonePower(power_state)
             if response_data is None:
                 _LOGGER.warning("Function setChromazonePower, parameter %s is not supported", power_state)
                 return False
-            
             new_state = self._get_tzl_power_state(response_data)
             expected_state = (power_state == "ON")
-            
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Úspěšně %s TZL světla%s",
-                    "zapnuto" if power_state == "ON" else "vypnuto",
-                    " (2. pokus)" if is_retry else ""
+                    "Successfully %s TZL lights%s",
+                    "turned on" if power_state == "ON" else "turned off",
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "TZL světla nebyla %s. Očekávaný stav: %s, Aktuální stav: %s%s",
-                    "zapnuto" if power_state == "ON" else "vypnuto",
-                    expected_state,
-                    new_state,
-                    " (2. pokus)" if is_retry else ""
+                    "TZL lights were not %s. Expected: %s, Got: %s%s",
+                    "turned on" if power_state == "ON" else "turned off",
+                    expected_state, new_state,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        """Zapnutí TZL světel."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_tzl_power_state("ON")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout TZL světla")
+                _LOGGER.info("Retrying TZL lights on")
                 success = await self._try_set_tzl_power_state("ON", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning on TZL lights: %s", str(e))
@@ -802,32 +688,26 @@ class SpaTzlPowerSwitch(SpaSwitchBase):
             self._shared_data.resume_updates()
 
     async def async_turn_off(self, **kwargs):
-        """Vypnutí TZL světel."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_tzl_power_state("OFF")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout TZL světla")
+                _LOGGER.info("Retrying TZL lights off")
                 success = await self._try_set_tzl_power_state("OFF", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning off TZL lights: %s", str(e))
         finally:
             self._shared_data.resume_updates()
 
+
 class SpaFilter2Switch(SpaSwitchBase):
-    """Přepínač pro druhý filtr (spa_filter_2)."""
-    
+    """Switch for second filter."""
+
     def __init__(self, shared_data, device_info, unique_id_suffix, client):
-        """Inicializace přepínače druhého filtru."""
         self._shared_data = shared_data
         self._attr_device_info = device_info
-        self._attr_entity_category = EntityCategory.CONFIG  # sekce Nastavení na kartě zařízení
+        self._attr_entity_category = EntityCategory.CONFIG
         self._client = client
         self._attr_unique_id = f"switch.spa_filter_2{unique_id_suffix}"
         self._attr_translation_key = "filter_2"
@@ -836,23 +716,20 @@ class SpaFilter2Switch(SpaSwitchBase):
 
     @property
     def available(self) -> bool:
-        """Indikuje, zda je entita dostupná pro ovládání."""
         return not self._is_processing
-        
+
     @property
     def icon(self):
         if self._is_processing:
-            return "mdi:sync"  # Ikona pro zpracování
+            return "mdi:sync"
         if self.is_on:
             return "mdi:water-sync"
         else:
             return "mdi:water-remove"
 
     def _get_filter2_state(self, data):
-        """Získá stav druhého filtru z dat."""
         if not data:
             return False
-        # Najít druhý filtr (port "1")
         filter_comp = next(
             (
                 comp
@@ -862,65 +739,52 @@ class SpaFilter2Switch(SpaSwitchBase):
             None,
         )
         if filter_comp:
-            # Pokud je stav "DISABLED", switch je vypnutý, jinak zapnutý
             return filter_comp["value"] != "DISABLED"
         return False
 
     async def async_update(self):
-        """Aktualizace stavu přepínače."""
         data = self._shared_data.data
         if data:
             self._attr_is_on = self._get_filter2_state(data)
             _LOGGER.debug("Updated Filter 2: %s", self._attr_is_on)
 
     async def _try_set_filter2_state(self, state: str, is_retry: bool = False) -> bool:
-        """Pokus o nastavení stavu druhého filtru s možností opakování."""
-        self._is_processing = True  # Zneplatnění tlačítka
+        self._is_processing = True
         self.async_write_ha_state()
-        
         try:
             response_data = await self._client.setFilter2Toggle(state)
             if response_data is None:
                 _LOGGER.warning("Function setFilter2Toggle, parameter %s is not supported", state)
                 return False
-            
             new_state = self._get_filter2_state(response_data)
             expected_state = (state == "ON")
-            
             if new_state == expected_state:
                 self._attr_is_on = expected_state
                 _LOGGER.info(
-                    "Úspěšně %s druhý filtr%s",
-                    "zapnuto" if state == "ON" else "vypnuto",
-                    " (2. pokus)" if is_retry else ""
+                    "Successfully %s filter 2%s",
+                    "turned on" if state == "ON" else "turned off",
+                    " (retry)" if is_retry else ""
                 )
                 return True
             else:
                 _LOGGER.warning(
-                    "Druhý filtr nebyl %s. Očekávaný stav: %s, Aktuální stav: %s%s",
-                    "zapnuto" if state == "ON" else "vypnuto",
-                    expected_state,
-                    new_state,
-                    " (2. pokus)" if is_retry else ""
+                    "Filter 2 was not %s. Expected: %s, Got: %s%s",
+                    "turned on" if state == "ON" else "turned off",
+                    expected_state, new_state,
+                    " (retry)" if is_retry else ""
                 )
                 return False
         finally:
-            self._is_processing = False  # Obnovení tlačítka
+            self._is_processing = False
             self.async_write_ha_state()
 
     async def async_turn_on(self, **kwargs):
-        """Zapnutí druhého filtru."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_filter2_state("ON")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu zapnout druhý filtr")
+                _LOGGER.info("Retrying filter 2 on")
                 success = await self._try_set_filter2_state("ON", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning on filter 2: %s", str(e))
@@ -928,20 +792,97 @@ class SpaFilter2Switch(SpaSwitchBase):
             self._shared_data.resume_updates()
 
     async def async_turn_off(self, **kwargs):
-        """Vypnutí druhého filtru."""
         try:
             self._shared_data.pause_updates()
-            
-            # První pokus
             success = await self._try_set_filter2_state("OFF")
-            
-            # Druhý pokus pokud první selhal
             if not success:
-                _LOGGER.info("Zkouším znovu vypnout druhý filtr")
+                _LOGGER.info("Retrying filter 2 off")
                 success = await self._try_set_filter2_state("OFF", True)
-                
             await self._shared_data.async_force_update()
         except Exception as e:
             _LOGGER.error("Error turning off filter 2: %s", str(e))
+        finally:
+            self._shared_data.resume_updates()
+
+
+class SpaPanelLockSwitch(SpaSwitchBase):
+    """Switch to lock/unlock the physical spa control panel."""
+
+    def __init__(self, shared_data, device_info, unique_id_suffix, client):
+        self._shared_data = shared_data
+        self._attr_device_info = device_info
+        self._client = client
+        self._attr_unique_id = f"switch.spa_panel_lock{unique_id_suffix}"
+        self._attr_translation_key = "panel_lock"
+        self._attr_icon = "mdi:lock"
+        self._attr_entity_category = EntityCategory.CONFIG
+        self._is_processing = False
+
+    @property
+    def available(self) -> bool:
+        return not self._is_processing
+
+    @property
+    def icon(self):
+        if self._is_processing:
+            return "mdi:sync"
+        if self.is_on:
+            return "mdi:lock"
+        else:
+            return "mdi:lock-open"
+
+    def _get_panel_lock_state(self, data):
+        """Read panel lock state from spa data payload."""
+        if not data:
+            return False
+        # Uses 'panelLock' flag parsed as a Python boolean by the client object
+        return bool(data.get("panelLock", False))
+
+    async def async_update(self):
+        data = self._shared_data.data
+        if data:
+            self._attr_is_on = self._get_panel_lock_state(data)
+            _LOGGER.debug("Updated Panel Lock: %s", self._attr_is_on)
+
+    async def _try_set_panel_lock(self, locked: bool, is_retry: bool = False) -> bool:
+        """Attempt to set panel lock state with optional retry."""
+        self._is_processing = True
+        self.async_write_ha_state()
+        try:
+            # Pass raw boolean flag (True/False) directly to the wrapper library method
+            response_data = await self._client.setPanelLock(locked)
+            if response_data is None:
+                _LOGGER.warning("setPanelLock(%s) returned None", locked)
+                return False
+            return True
+        finally:
+            self._is_processing = False
+            self.async_write_ha_state()
+
+    async def async_turn_on(self, **kwargs):
+        """Lock the panel."""
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_panel_lock(True)
+            if not success:
+                _LOGGER.info("Retrying panel lock engage")
+                success = await self._try_set_panel_lock(True, True)
+            await self._shared_data.async_force_update()
+        except Exception as e:
+            _LOGGER.error("Error engaging panel lock: %s", str(e))
+        finally:
+            self._shared_data.resume_updates()
+
+    async def async_turn_off(self, **kwargs):
+        """Unlock the panel."""
+        try:
+            self._shared_data.pause_updates()
+            success = await self._try_set_panel_lock(False)
+            if not success:
+                _LOGGER.info("Retrying panel lock release")
+                success = await self._try_set_panel_lock(False, True)
+            await self._shared_data.async_force_update()
+        except Exception as e:
+            _LOGGER.error("Error releasing panel lock: %s", str(e))
         finally:
             self._shared_data.resume_updates()

--- a/custom_components/control_my_spa/switch.py
+++ b/custom_components/control_my_spa/switch.py
@@ -48,7 +48,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     )
 
     entities = [SpaLightSwitch(shared_data, device_info, unique_id_suffix, light, len(lights)) for light in lights]
-    entities += [SpaPumpSwitch(shared_data, device_info, pump, len(pumps), unique_id_suffix) for pump in pumps]
+    # Pump/jet control moved to fan.py (fan.spa_pump). Switch pump entity intentionally not created.
     entities += [SpaBlowerSwitch(shared_data, device_info, unique_id_suffix, blower, len(blowers)) for blower in blowers]
 
     if len(filters) >= 2:

--- a/custom_components/control_my_spa/translations/cs.json
+++ b/custom_components/control_my_spa/translations/cs.json
@@ -172,20 +172,6 @@
         "name": "Čas vířivky"
       }
     },
-    "select": {
-      "tzl_color_select": {
-        "name": "TZL barva"
-      },
-      "tzl_color_select_1": {
-        "name": "TZL barva A"
-      },
-      "tzl_color_select_2": {
-        "name": "TZL barva B"
-      },
-      "tzl_color_select_3": {
-        "name": "TZL barva C"
-      }
-    },
     "light": {
       "tzl_zone_light": {
         "name": "Chromazone - Světlo"
@@ -613,6 +599,13 @@
           "on": "Zapnuto",
           "off": "Vypnuto"
         }
+      },
+      "panel_lock": {
+        "name": "Zámek panelu",
+        "state": {
+          "on": "Zamčeno",
+          "off": "Odemčeno"
+        }
       }
     },
     "fan": {
@@ -697,4 +690,3 @@
     }
   }
 }
-   

--- a/custom_components/control_my_spa/translations/en.json
+++ b/custom_components/control_my_spa/translations/en.json
@@ -599,6 +599,13 @@
           "on": "On",
           "off": "Off"
         }
+      },
+      "panel_lock": {
+        "name": "Panel lock",
+        "state": {
+          "on": "Locked",
+          "off": "Unlocked"
+        }
       }
     },
     "fan": {


### PR DESCRIPTION
This PR refactors how multi-speed pumps are handled by migrating them from legacy binary on/off switch entities to a robust fan entity structure utilizing Home Assistant's native preset_modes.

The Problem

The legacy implementation registered all spa pumps purely as binary on/off switches. For spas equipped with multi-speed pumps, this created severe integration issues:

Command inputs to change speeds were ignored or improperly formatted.

The Home Assistant UI would "rubber-band" (flipping states and snapping back) because it could not reconcile a single binary switch state with a pump that was physically operating in a secondary speed mode (e.g., LOW vs HIGH).

Turning a pump "Off" when the motherboard required it to stay on for physical safety constraints (like heater regulation) resulted in state desynchronization.

The Solution & Hardware Verification

This refactor has been actively deployed and end-to-end stress-tested on a Balboa 6013 spa pack (BP Series) equipped with a 3-speed primary pump (Off/Low/High) and a 2-speed secondary pump (Off/High).

switch.py: Modified to explicitly prevent the generation of the legacy binary pump switches. This ensures they do not conflict with or double-register alongside the new fan entities.

fan.py: Re-written to implement standard Home Assistant Fan Entity properties. It maps available speeds to discrete presets (LOW and HIGH), allowing the user to cleanly step between circulation/heating modes and full massage jet velocity.

Testing confirmed that the integration now cleanly handles remote cloud state changes, polling updates, and gracefully respects hardcoded motherboard overrides (such as refusing an OFF command on Pump 1 when the heater is engaged, or preventing Pump 2 from firing due to load-shedding safety rules when power limits are met).

Example Dashboard Deployment (Mushroom Cards)

To demonstrate how the new fan preset logic integrates into a clean user interface, here is the functional dashboard YAML created during user testing. This replaces the confusing dropdown sliders and native switches with intuitive, color-coded hardware mapping.

YAML
          - type: custom:stack-in-card
            title: Spa Pump & Jets Controls
            cards:
              - type: markdown
                content: |
                  **Primary Pump (Jets 1)**
                  *Controls water circulation, heating flow, and main massage jets.*
              - type: horizontal-stack
                cards:
                  - type: custom:mushroom-template-card
                    entity: fan.spa_pump_1
                    primary: "OFF"
                    secondary: "Stop"
                    icon: mdi:power
                    icon_color: "{{ 'green' if is_state('fan.spa_pump_1', 'off') else 'grey' }}"
                    tap_action:
                      action: perform-action
                      perform_action: fan.turn_off
                      target:
                        entity_id: fan.spa_pump_1
                  - type: custom:mushroom-template-card
                    entity: fan.spa_pump_1
                    primary: "LOW"
                    secondary: "Circulate / Heat"
                    icon: mdi:waves-arrow-right
                    icon_color: "{{ 'blue' if is_state('fan.spa_pump_1', 'on') and (state_attr('fan.spa_pump_1', 'preset_mode') | upper) == 'LOW' else 'grey' }}"
                    tap_action:
                      action: perform-action
                      perform_action: fan.set_preset_mode
                      target:
                        entity_id: fan.spa_pump_1
                      data:
                        preset_mode: "LOW"
                  - type: custom:mushroom-template-card
                    entity: fan.spa_pump_1
                    primary: "HIGH"
                    secondary: "Massage Jets"
                    icon: mdi:hydro-power
                    icon_color: "{{ 'red' if is_state('fan.spa_pump_1', 'on') and (state_attr('fan.spa_pump_1', 'preset_mode') | upper) == 'HIGH' else 'grey' }}"
                    tap_action:
                      action: perform-action
                      perform_action: fan.set_preset_mode
                      target:
                        entity_id: fan.spa_pump_1
                      data:
                        preset_mode: "HIGH"
              - type: markdown
                content: |
                  **Secondary Pump (Jets 2)**
                  *Controls the extra massage jets.*
              - type: horizontal-stack
                cards:
                  - type: custom:mushroom-template-card
                    entity: fan.spa_pump_2
                    primary: "OFF"
                    secondary: "Stop"
                    icon: mdi:power
                    icon_color: "{{ 'green' if is_state('fan.spa_pump_2', 'off') else 'grey' }}"
                    tap_action:
                      action: perform-action
                      perform_action: fan.turn_off
                      target:
                        entity_id: fan.spa_pump_2
                  - type: custom:mushroom-template-card
                    entity: fan.spa_pump_2
                    primary: "HIGH"
                    secondary: "Massage Jets"
                    icon: mdi:hydro-power
                    icon_color: "{{ 'red' if is_state('fan.spa_pump_2', 'on') else 'grey' }}"
                    tap_action:
                      action: perform-action
                      perform_action: fan.set_preset_mode
                      target:
                        entity_id: fan.spa_pump_2
                      data:
                        preset_mode: "HIGH"